### PR TITLE
[NFC] Use default arguments in functions, rather than global defaults

### DIFF
--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -115,7 +115,7 @@ open class PerformanceTestCase: XCTestCase {
         }
     }
 
-    private func timeClosure<C>(
+    private func timeClosure <C> (
         point: Double,
         mock: inout C,
         closure: RunFunction<C>

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -25,9 +25,6 @@ open class PerformanceTestCase: XCTestCase {
 
         // The default minimum correlation to accept
         public static let defaultMinimumCorrelation: Double = 0.90
-
-        // Default number of trials for performance testing
-        public static let defaultTrialCount: Int = 10
     }
 
     /// Classes of complexity (big-oh style).
@@ -102,7 +99,7 @@ open class PerformanceTestCase: XCTestCase {
         trialCode: RunFunction<C>,
         isMutating: Bool,
         testPoints: [Double] = Scale.medium,
-        trialCount: Int = Configuration.defaultTrialCount
+        trialCount: Int = 10
     ) -> BenchmarkData
     {
         return testPoints.map { point in

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -19,7 +19,6 @@ open class PerformanceTestCase: XCTestCase {
     // MARK: - Nested Types
 
     public struct Configuration {
-
         // Controls whether any methods in this file print debugging information
         public static let debug: Bool = true
     }
@@ -63,18 +62,6 @@ open class PerformanceTestCase: XCTestCase {
 
     /// Ranges of values to use for testPoints (values of `n` in `O(f(n))`).
     public struct Scale {
-
-        // Creates an array of Doubles in an exponential series.
-        private static func exponentialSeries(
-            size: Int,
-            from start: Double,
-            to end: Double
-        ) -> [Double]
-        {
-            let base = pow(end - start + 1, 1 / (Double(size)-1))
-            return (0..<size).map { pow(base, Double($0)) + start - 1 }.map(round)
-        }
-
         public static let tiny   = exponentialSeries(size: 10, from: 5,    to: 100)
         public static let small  = exponentialSeries(size: 10, from: 10,   to: 1_000)
         public static let medium = exponentialSeries(size: 10, from: 100,  to: 1_000_000)
@@ -236,4 +223,10 @@ open class PerformanceTestCase: XCTestCase {
 
         return sqrt(numerator / denominator) * slope
     }
+}
+
+// Creates an array of Doubles in an exponential series.
+private func exponentialSeries(size: Int, from start: Double, to end: Double) -> [Double] {
+    let base = pow(end - start + 1, 1 / (Double(size)-1))
+    return (0..<size).map { pow(base, Double($0)) + start - 1 }.map(round)
 }

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -10,7 +10,7 @@ import XCTest
 
 open class PerformanceTestCase: XCTestCase {
 
-    // MARK - Associated Types
+    // MARK: - Associated Types
 
     public typealias SetupFunction<C> = (inout C, Double) -> ()
     public typealias RunFunction<C> = (inout C, Double) -> ()

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -31,9 +31,6 @@ open class PerformanceTestCase: XCTestCase {
 
         // Default accuracy to use when testing the slope of constant-time performance
         public static let defaultConstantTimeSlopeAccuracy: Double = 0.01
-
-        // Default scale to use for test size
-        public static let defaultScale: [Double] = Scale.medium
     }
 
     /// Classes of complexity (big-oh style).
@@ -107,7 +104,7 @@ open class PerformanceTestCase: XCTestCase {
         setupFunction: SetupFunction<C>,
         trialCode: RunFunction<C>,
         isMutating: Bool,
-        testPoints: [Double] = Configuration.defaultScale,
+        testPoints: [Double] = Scale.medium,
         trialCount: Int = Configuration.defaultTrialCount
     ) -> BenchmarkData
     {

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -10,13 +10,15 @@ import XCTest
 
 open class PerformanceTestCase: XCTestCase {
 
-    /// MARK - Associated types.
+    // MARK - Associated Types
 
     public typealias SetupFunction<C> = (inout C, Double) -> ()
 
     public typealias RunFunction<C> = (inout C, Double) -> ()
 
     public typealias BenchmarkData = [(Double, Double)]
+
+    // MARK: - Nested Types
 
     public struct Configuration {
 
@@ -77,7 +79,12 @@ open class PerformanceTestCase: XCTestCase {
     public struct Scale {
 
         // Creates an array of Doubles in an exponential series.
-        private static func exponentialSeries(size: Int, from start: Double, to end: Double) -> [Double] {
+        private static func exponentialSeries(
+            size: Int,
+            from start: Double,
+            to end: Double
+        ) -> [Double]
+        {
             let base = pow(end - start + 1, 1 / (Double(size)-1))
             return (0..<size).map { pow(base, Double($0)) + start - 1 }.map(round)
         }
@@ -86,10 +93,15 @@ open class PerformanceTestCase: XCTestCase {
         public static let small  = exponentialSeries(size: 10, from: 10,   to: 1_000)
         public static let medium = exponentialSeries(size: 10, from: 100,  to: 1_000_000)
         public static let large  = exponentialSeries(size: 10, from: 1000, to: 1_000_000_000)
-
     }
 
-    /// MARK - Public functions.
+    private struct RegressionData {
+        public let slope: Double
+        public let intercept: Double
+        public let correlation: Double
+    }
+
+    /// MARK - Instance Methods
 
     /// Benchmarks the performance of an closure.
     public func benchmarkClosure <C> (
@@ -177,24 +189,15 @@ open class PerformanceTestCase: XCTestCase {
             print("\(#function): warning: constant-time complexity is not well-supported. You",
                 "probably mean assertConstantTimePerformance")
         default:
-            () // do nothing
+            break
         }
 
         XCTAssert(results.correlation >= minimumCorrelation)
     }
 
-    /// MARK - Private associated types
-
-    private struct RegressionData {
-        public let slope: Double
-        public let intercept: Double
-        public let correlation: Double
-    }
-
-    /// MARK - Private functions
-
     /// Performs linear regression on the given dataset.
     private func linearRegression(_ data: BenchmarkData) -> RegressionData {
+
         let xs = data.map { $0.0 }
         let ys = data.map { $0.1 }
         let sumOfXs = xs.reduce(0, +)
@@ -208,7 +211,12 @@ open class PerformanceTestCase: XCTestCase {
 
         let intercept = interceptNumerator / denominator
         let slope = slopeNumerator / denominator
-        let correlation = calculateCorrelation(data, sumOfXs: sumOfXs, sumOfYs: sumOfYs, slope: slope)
+
+        let correlation = calculateCorrelation(data,
+           sumOfXs: sumOfXs,
+           sumOfYs: sumOfYs,
+           slope: slope
+        )
 
         return RegressionData(slope: slope, intercept: intercept, correlation: correlation)
     }
@@ -219,7 +227,7 @@ open class PerformanceTestCase: XCTestCase {
         sumOfXs: Double,
         sumOfYs: Double,
         slope: Double
-        ) -> Double
+    ) -> Double
     {
 
         let meanOfYs = sumOfYs / Double(data.count)

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -28,9 +28,6 @@ open class PerformanceTestCase: XCTestCase {
 
         // Default number of trials for performance testing
         public static let defaultTrialCount: Int = 10
-
-        // Default accuracy to use when testing the slope of constant-time performance
-        public static let defaultConstantTimeSlopeAccuracy: Double = 0.01
     }
 
     /// Classes of complexity (big-oh style).
@@ -139,7 +136,7 @@ open class PerformanceTestCase: XCTestCase {
     /// Assert that the data indicates that performance is constant-time ( O(1) ).
     public func assertConstantTimePerformance(
         _ data: BenchmarkData,
-        slopeAccuracy: Double = Configuration.defaultConstantTimeSlopeAccuracy
+        slopeAccuracy: Double = 0.01
     )
     {
         let results = linearRegression(data)

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -22,9 +22,6 @@ open class PerformanceTestCase: XCTestCase {
 
         // Controls whether any methods in this file print debugging information
         public static let debug: Bool = true
-
-        // The default minimum correlation to accept
-        public static let defaultMinimumCorrelation: Double = 0.90
     }
 
     /// Classes of complexity (big-oh style).
@@ -157,7 +154,7 @@ open class PerformanceTestCase: XCTestCase {
     public func assertPerformanceComplexity(
         _ data: BenchmarkData,
         complexity: Complexity,
-        minimumCorrelation: Double = Configuration.defaultMinimumCorrelation
+        minimumCorrelation: Double = 0.9
     )
     {
         let mappedData = complexity.mapDataForLinearFit(data)

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -13,9 +13,7 @@ open class PerformanceTestCase: XCTestCase {
     // MARK - Associated Types
 
     public typealias SetupFunction<C> = (inout C, Double) -> ()
-
     public typealias RunFunction<C> = (inout C, Double) -> ()
-
     public typealias BenchmarkData = [(Double, Double)]
 
     // MARK: - Nested Types


### PR DESCRIPTION
As each of these were only used once (particularly after the `mutating`/`non-mutating` assertions we factored out), it may make sense to just declare these within the function that requires this information.