### PR TITLE
[NFC] Maybe no typealiases

### DIFF
--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -115,7 +115,7 @@ open class PerformanceTestCase: XCTestCase {
         }
     }
 
-    private func timeClosure<C>(
+    private func timeClosure <C> (
         point: Double,
         mock: inout C,
         closure: RunFunction<C>

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -25,9 +25,6 @@ open class PerformanceTestCase: XCTestCase {
 
         // The default minimum correlation to accept
         public static let defaultMinimumCorrelation: Double = 0.90
-
-        // Default number of trials for performance testing
-        public static let defaultTrialCount: Int = 10
     }
 
     /// Classes of complexity (big-oh style).
@@ -102,7 +99,7 @@ open class PerformanceTestCase: XCTestCase {
         trialCode: RunFunction<C>,
         isMutating: Bool,
         testPoints: [Double] = Scale.medium,
-        trialCount: Int = Configuration.defaultTrialCount
+        trialCount: Int = 10
     ) -> BenchmarkData
     {
         return testPoints.map { point in

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -12,7 +12,6 @@ open class PerformanceTestCase: XCTestCase {
 
     // MARK: - Associated Types
 
-    public typealias SetUp<C> = (inout C, Double) -> Void
     public typealias Run<C> = (inout C, Double) -> Void
     public typealias Benchmark = [(Double, Double)]
 
@@ -79,7 +78,7 @@ open class PerformanceTestCase: XCTestCase {
     /// Benchmarks the performance of an closure.
     public func benchmarkClosure <C> (
         mock object: C,
-        setupFunction: SetUp<C>,
+        setupFunction: (inout C, Double) -> Void,
         trialCode: Run<C>,
         isMutating: Bool,
         testPoints: [Double] = Scale.medium,

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -12,6 +12,7 @@ open class PerformanceTestCase: XCTestCase {
 
     // MARK: - Associated Types
 
+    public typealias SetUp <C> = (inout C, Double) -> Void
     public typealias Benchmark = [(Double, Double)]
 
     // MARK: - Nested Types
@@ -77,7 +78,7 @@ open class PerformanceTestCase: XCTestCase {
     /// Benchmarks the performance of an closure.
     public func benchmarkClosure <C> (
         mock object: C,
-        setupFunction: (inout C, Double) -> Void,
+        setUp: SetUp<C>,
         trialCode: (inout C, Double) -> Void,
         isMutating: Bool,
         testPoints: [Double] = Scale.medium,
@@ -86,7 +87,7 @@ open class PerformanceTestCase: XCTestCase {
     {
         return testPoints.map { point in
             var pointMock = object
-            setupFunction(&pointMock, point)
+            setUp(&pointMock, point)
             let average = (0..<trialCount).map { _ in
                 // if the closure is mutating, create a copy before timing the closure
                 if isMutating {

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -12,8 +12,8 @@ open class PerformanceTestCase: XCTestCase {
 
     // MARK: - Associated Types
 
-    public typealias SetUp<C> = (inout C, Double) -> ()
-    public typealias Run<C> = (inout C, Double) -> ()
+    public typealias SetUp<C> = (inout C, Double) -> Void
+    public typealias Run<C> = (inout C, Double) -> Void
     public typealias Benchmark = [(Double, Double)]
 
     // MARK: - Nested Types

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -19,7 +19,6 @@ open class PerformanceTestCase: XCTestCase {
     // MARK: - Nested Types
 
     public struct Configuration {
-
         // Controls whether any methods in this file print debugging information
         public static let debug: Bool = true
     }
@@ -63,18 +62,6 @@ open class PerformanceTestCase: XCTestCase {
 
     /// Ranges of values to use for testPoints (values of `n` in `O(f(n))`).
     public struct Scale {
-
-        // Creates an array of Doubles in an exponential series.
-        private static func exponentialSeries(
-            size: Int,
-            from start: Double,
-            to end: Double
-        ) -> [Double]
-        {
-            let base = pow(end - start + 1, 1 / (Double(size)-1))
-            return (0..<size).map { pow(base, Double($0)) + start - 1 }.map(round)
-        }
-
         public static let tiny   = exponentialSeries(size: 10, from: 5,    to: 100)
         public static let small  = exponentialSeries(size: 10, from: 10,   to: 1_000)
         public static let medium = exponentialSeries(size: 10, from: 100,  to: 1_000_000)
@@ -236,4 +223,10 @@ open class PerformanceTestCase: XCTestCase {
 
         return sqrt(numerator / denominator) * slope
     }
+}
+
+// Creates an array of Doubles in an exponential series.
+private func exponentialSeries(size: Int, from start: Double, to end: Double) -> [Double] {
+    let base = pow(end - start + 1, 1 / (Double(size)-1))
+    return (0..<size).map { pow(base, Double($0)) + start - 1 }.map(round)
 }

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -12,7 +12,6 @@ open class PerformanceTestCase: XCTestCase {
 
     // MARK: - Associated Types
 
-    public typealias Run<C> = (inout C, Double) -> Void
     public typealias Benchmark = [(Double, Double)]
 
     // MARK: - Nested Types
@@ -79,7 +78,7 @@ open class PerformanceTestCase: XCTestCase {
     public func benchmarkClosure <C> (
         mock object: C,
         setupFunction: (inout C, Double) -> Void,
-        trialCode: Run<C>,
+        trialCode: (inout C, Double) -> Void,
         isMutating: Bool,
         testPoints: [Double] = Scale.medium,
         trialCount: Int = 10
@@ -104,7 +103,7 @@ open class PerformanceTestCase: XCTestCase {
     private func timeClosure <C> (
         point: Double,
         mock: inout C,
-        closure: Run<C>
+        closure: (inout C, Double) -> Void
     ) -> Double
     {
         let startTime = CFAbsoluteTimeGetCurrent()

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -10,7 +10,7 @@ import XCTest
 
 open class PerformanceTestCase: XCTestCase {
 
-    // MARK - Associated Types
+    // MARK: - Associated Types
 
     public typealias SetupFunction<C> = (inout C, Double) -> ()
     public typealias RunFunction<C> = (inout C, Double) -> ()

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -31,9 +31,6 @@ open class PerformanceTestCase: XCTestCase {
 
         // Default accuracy to use when testing the slope of constant-time performance
         public static let defaultConstantTimeSlopeAccuracy: Double = 0.01
-
-        // Default scale to use for test size
-        public static let defaultScale: [Double] = Scale.medium
     }
 
     /// Classes of complexity (big-oh style).
@@ -107,7 +104,7 @@ open class PerformanceTestCase: XCTestCase {
         setupFunction: SetupFunction<C>,
         trialCode: RunFunction<C>,
         isMutating: Bool,
-        testPoints: [Double] = Configuration.defaultScale,
+        testPoints: [Double] = Scale.medium,
         trialCount: Int = Configuration.defaultTrialCount
     ) -> BenchmarkData
     {

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -10,13 +10,15 @@ import XCTest
 
 open class PerformanceTestCase: XCTestCase {
 
-    /// MARK - Associated types.
+    // MARK - Associated Types
 
     public typealias SetupFunction<C> = (inout C, Double) -> ()
 
     public typealias RunFunction<C> = (inout C, Double) -> ()
 
     public typealias BenchmarkData = [(Double, Double)]
+
+    // MARK: - Nested Types
 
     public struct Configuration {
 
@@ -77,7 +79,12 @@ open class PerformanceTestCase: XCTestCase {
     public struct Scale {
 
         // Creates an array of Doubles in an exponential series.
-        private static func exponentialSeries(size: Int, from start: Double, to end: Double) -> [Double] {
+        private static func exponentialSeries(
+            size: Int,
+            from start: Double,
+            to end: Double
+        ) -> [Double]
+        {
             let base = pow(end - start + 1, 1 / (Double(size)-1))
             return (0..<size).map { pow(base, Double($0)) + start - 1 }.map(round)
         }
@@ -86,10 +93,15 @@ open class PerformanceTestCase: XCTestCase {
         public static let small  = exponentialSeries(size: 10, from: 10,   to: 1_000)
         public static let medium = exponentialSeries(size: 10, from: 100,  to: 1_000_000)
         public static let large  = exponentialSeries(size: 10, from: 1000, to: 1_000_000_000)
-
     }
 
-    /// MARK - Public functions.
+    private struct RegressionData {
+        public let slope: Double
+        public let intercept: Double
+        public let correlation: Double
+    }
+
+    /// MARK - Instance Methods
 
     /// Benchmarks the performance of an closure.
     public func benchmarkClosure <C> (
@@ -177,24 +189,15 @@ open class PerformanceTestCase: XCTestCase {
             print("\(#function): warning: constant-time complexity is not well-supported. You",
                 "probably mean assertConstantTimePerformance")
         default:
-            () // do nothing
+            break
         }
 
         XCTAssert(results.correlation >= minimumCorrelation)
     }
 
-    /// MARK - Private associated types
-
-    private struct RegressionData {
-        public let slope: Double
-        public let intercept: Double
-        public let correlation: Double
-    }
-
-    /// MARK - Private functions
-
     /// Performs linear regression on the given dataset.
     private func linearRegression(_ data: BenchmarkData) -> RegressionData {
+
         let xs = data.map { $0.0 }
         let ys = data.map { $0.1 }
         let sumOfXs = xs.reduce(0, +)
@@ -208,7 +211,12 @@ open class PerformanceTestCase: XCTestCase {
 
         let intercept = interceptNumerator / denominator
         let slope = slopeNumerator / denominator
-        let correlation = calculateCorrelation(data, sumOfXs: sumOfXs, sumOfYs: sumOfYs, slope: slope)
+
+        let correlation = calculateCorrelation(data,
+           sumOfXs: sumOfXs,
+           sumOfYs: sumOfYs,
+           slope: slope
+        )
 
         return RegressionData(slope: slope, intercept: intercept, correlation: correlation)
     }
@@ -219,7 +227,7 @@ open class PerformanceTestCase: XCTestCase {
         sumOfXs: Double,
         sumOfYs: Double,
         slope: Double
-        ) -> Double
+    ) -> Double
     {
 
         let meanOfYs = sumOfYs / Double(data.count)

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -28,9 +28,6 @@ open class PerformanceTestCase: XCTestCase {
 
         // Default number of trials for performance testing
         public static let defaultTrialCount: Int = 10
-
-        // Default accuracy to use when testing the slope of constant-time performance
-        public static let defaultConstantTimeSlopeAccuracy: Double = 0.01
     }
 
     /// Classes of complexity (big-oh style).
@@ -139,7 +136,7 @@ open class PerformanceTestCase: XCTestCase {
     /// Assert that the data indicates that performance is constant-time ( O(1) ).
     public func assertConstantTimePerformance(
         _ data: BenchmarkData,
-        slopeAccuracy: Double = Configuration.defaultConstantTimeSlopeAccuracy
+        slopeAccuracy: Double = 0.01
     )
     {
         let results = linearRegression(data)

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -22,9 +22,6 @@ open class PerformanceTestCase: XCTestCase {
 
         // Controls whether any methods in this file print debugging information
         public static let debug: Bool = true
-
-        // The default minimum correlation to accept
-        public static let defaultMinimumCorrelation: Double = 0.90
     }
 
     /// Classes of complexity (big-oh style).
@@ -157,7 +154,7 @@ open class PerformanceTestCase: XCTestCase {
     public func assertPerformanceComplexity(
         _ data: BenchmarkData,
         complexity: Complexity,
-        minimumCorrelation: Double = Configuration.defaultMinimumCorrelation
+        minimumCorrelation: Double = 0.9
     )
     {
         let mappedData = complexity.mapDataForLinearFit(data)

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -13,9 +13,7 @@ open class PerformanceTestCase: XCTestCase {
     // MARK - Associated Types
 
     public typealias SetupFunction<C> = (inout C, Double) -> ()
-
     public typealias RunFunction<C> = (inout C, Double) -> ()
-
     public typealias BenchmarkData = [(Double, Double)]
 
     // MARK: - Nested Types

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -12,9 +12,9 @@ open class PerformanceTestCase: XCTestCase {
 
     // MARK: - Associated Types
 
-    public typealias SetupFunction<C> = (inout C, Double) -> ()
-    public typealias RunFunction<C> = (inout C, Double) -> ()
-    public typealias BenchmarkData = [(Double, Double)]
+    public typealias SetUp<C> = (inout C, Double) -> ()
+    public typealias Run<C> = (inout C, Double) -> ()
+    public typealias Benchmark = [(Double, Double)]
 
     // MARK: - Nested Types
 
@@ -38,7 +38,7 @@ open class PerformanceTestCase: XCTestCase {
         /// Maps data representing performance of a certain complexity so that it
         /// can be fit with linear regression. This is done by applying the inverse
         /// function of the expected performance function.
-        public func mapDataForLinearFit(_ data: BenchmarkData) -> BenchmarkData {
+        public func mapDataForLinearFit(_ data: Benchmark) -> Benchmark {
             switch self {
             case .constant:
                 return data
@@ -68,7 +68,7 @@ open class PerformanceTestCase: XCTestCase {
         public static let large  = exponentialSeries(size: 10, from: 1000, to: 1_000_000_000)
     }
 
-    private struct RegressionData {
+    private struct Regression {
         public let slope: Double
         public let intercept: Double
         public let correlation: Double
@@ -79,12 +79,12 @@ open class PerformanceTestCase: XCTestCase {
     /// Benchmarks the performance of an closure.
     public func benchmarkClosure <C> (
         mock object: C,
-        setupFunction: SetupFunction<C>,
-        trialCode: RunFunction<C>,
+        setupFunction: SetUp<C>,
+        trialCode: Run<C>,
         isMutating: Bool,
         testPoints: [Double] = Scale.medium,
         trialCount: Int = 10
-    ) -> BenchmarkData
+    ) -> Benchmark
     {
         return testPoints.map { point in
             var pointMock = object
@@ -105,7 +105,7 @@ open class PerformanceTestCase: XCTestCase {
     private func timeClosure <C> (
         point: Double,
         mock: inout C,
-        closure: RunFunction<C>
+        closure: Run<C>
     ) -> Double
     {
         let startTime = CFAbsoluteTimeGetCurrent()
@@ -116,7 +116,7 @@ open class PerformanceTestCase: XCTestCase {
 
     /// Assert that the data indicates that performance is constant-time ( O(1) ).
     public func assertConstantTimePerformance(
-        _ data: BenchmarkData,
+        _ data: Benchmark,
         slopeAccuracy: Double = 0.01
     )
     {
@@ -139,7 +139,7 @@ open class PerformanceTestCase: XCTestCase {
     /// complexity class. Optional parameter for minimum acceptable correlation.
     /// Use assertConstantTimePerformance for O(1) assertions
     public func assertPerformanceComplexity(
-        _ data: BenchmarkData,
+        _ data: Benchmark,
         complexity: Complexity,
         minimumCorrelation: Double = 0.9
     )
@@ -169,7 +169,7 @@ open class PerformanceTestCase: XCTestCase {
     }
 
     /// Performs linear regression on the given dataset.
-    private func linearRegression(_ data: BenchmarkData) -> RegressionData {
+    private func linearRegression(_ data: Benchmark) -> Regression {
 
         let xs = data.map { $0.0 }
         let ys = data.map { $0.1 }
@@ -191,12 +191,12 @@ open class PerformanceTestCase: XCTestCase {
            slope: slope
         )
 
-        return RegressionData(slope: slope, intercept: intercept, correlation: correlation)
+        return Regression(slope: slope, intercept: intercept, correlation: correlation)
     }
 
     /// Helper function to calculate the regression coefficient ("r") of the given dataset.
     private func calculateCorrelation(
-        _ data: BenchmarkData,
+        _ data: Benchmark,
         sumOfXs: Double,
         sumOfYs: Double,
         slope: Double

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -35,7 +35,7 @@ class ArrayTests: PerformanceTestCase {
     func testIsEmpty() {
         let data = benchmarkClosure(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setUp: constructSizeNArray,
             trialCode: { array, _ in _ = array.isEmpty },
             isMutating: false
         )
@@ -46,7 +46,7 @@ class ArrayTests: PerformanceTestCase {
     func testCount() {
         let data = benchmarkClosure(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setUp: constructSizeNArray,
             trialCode: { array, _ in _ = array.count },
             isMutating: false
         )
@@ -59,7 +59,7 @@ class ArrayTests: PerformanceTestCase {
     func testSubscript() {
         let data = benchmarkClosure(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setUp: constructSizeNArray,
             trialCode: { array, _ in _ = array[3] },
             isMutating: false
         )
@@ -70,7 +70,7 @@ class ArrayTests: PerformanceTestCase {
     func testFirst() {
         let data = benchmarkClosure(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setUp: constructSizeNArray,
             trialCode: { array, _ in _ = array.first },
             isMutating: false
         )
@@ -81,7 +81,7 @@ class ArrayTests: PerformanceTestCase {
     func testLast() {
         let data = benchmarkClosure(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setUp: constructSizeNArray,
             trialCode: { array, _ in _ = array.last },
             isMutating: false
         )
@@ -94,7 +94,7 @@ class ArrayTests: PerformanceTestCase {
     func testAppend() {
         let data = benchmarkClosure(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setUp: constructSizeNArray,
             trialCode: { array, _ in array.append(6) },
             isMutating: true
         )
@@ -105,7 +105,7 @@ class ArrayTests: PerformanceTestCase {
     func testInsert() {
         let data = benchmarkClosure(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setUp: constructSizeNArray,
             trialCode: { array, _ in
                 for _ in 0..<100 {
                     array.insert(6, at: 0)
@@ -122,7 +122,7 @@ class ArrayTests: PerformanceTestCase {
     func testRemove() {
         let data = benchmarkClosure(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setUp: constructSizeNArray,
             trialCode: { array, n in
                 for _ in 0..<100 {
                     _ = array.remove(at: 0)
@@ -141,7 +141,7 @@ class ArrayTests: PerformanceTestCase {
     func testSort() {
         let data = benchmarkClosure(
             mock: [],
-            setupFunction: constructRandomSizeNArray,
+            setUp: constructRandomSizeNArray,
             trialCode: { array, n in
                 array.sort()
             },
@@ -154,7 +154,7 @@ class ArrayTests: PerformanceTestCase {
     func testPartition() {
         let data = benchmarkClosure(
             mock: [],
-            setupFunction: constructRandomSizeNArray,
+            setUp: constructRandomSizeNArray,
             trialCode: { array, n in
                 _ = array.partition { element in element > 50 }
             },

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -13,7 +13,7 @@ class ArrayTests: PerformanceTestCase {
     /// MARK - Helper functions.
 
     // Constructs an array of size `n` with linearly increasing elements.
-    let constructSizeNArray: SetupFunction<[Int]> = { array, n in
+    let constructSizeNArray: SetUp<[Int]> = { array, n in
         array.reserveCapacity(Int(n))
         for i in 0..<Int(n) {
             array.append(i)
@@ -21,7 +21,7 @@ class ArrayTests: PerformanceTestCase {
     }
 
     // Constructs an array of size `n` with random elements.
-    let constructRandomSizeNArray: SetupFunction<[Int]> = { array, n in
+    let constructRandomSizeNArray: SetUp<[Int]> = { array, n in
         array.reserveCapacity(Int(n))
         for i in 0..<Int(n) {
             let randomNumber = Int(arc4random_uniform(UInt32(n)))

--- a/Tests/PerformanceTestingTests/ComplexityTests.swift
+++ b/Tests/PerformanceTestingTests/ComplexityTests.swift
@@ -16,89 +16,89 @@ class PerformanceTestingTests: PerformanceTestCase {
     // - MARK: Constant
 
     func testConstant() {
-        let data: BenchmarkData = [(1, 1.01), (2, 1.01), (3, 1.05), (4, 0.99)]
+        let data: Benchmark = [(1, 1.01), (2, 1.01), (3, 1.05), (4, 0.99)]
         assertConstantTimePerformance(data)
     }
 
     // - MARK: Logarithmic
 
     func testLogarithmicBaseTwoSlopeOne() {
-        let data: BenchmarkData = [(10, 3.32), (20, 4.32), (30, 4.91), (40, 5.32)]
+        let data: Benchmark = [(10, 3.32), (20, 4.32), (30, 4.91), (40, 5.32)]
         assertPerformanceComplexity(data, complexity: .logarithmic)
     }
 
     func testLogarithmicBaseTwoSlopeThree() {
-        let data: BenchmarkData = [(10, 4.90), (20, 5.91), (30, 6.49), (40, 6.90)]
+        let data: Benchmark = [(10, 4.90), (20, 5.91), (30, 6.49), (40, 6.90)]
         assertPerformanceComplexity(data, complexity: .logarithmic)
     }
 
     func testLogarithmicBaseESlopeOne() {
-        let data: BenchmarkData = [(10, 2.30), (20, 2.99), (30, 3.40), (40, 3.69)]
+        let data: Benchmark = [(10, 2.30), (20, 2.99), (30, 3.40), (40, 3.69)]
         assertPerformanceComplexity(data, complexity: .logarithmic)
     }
 
     func testLogarithmicBaseESlopeThree() {
-        let data: BenchmarkData = [(10, 3.40), (20, 4.09), (30, 4.50), (40, 4.79)]
+        let data: Benchmark = [(10, 3.40), (20, 4.09), (30, 4.50), (40, 4.79)]
         assertPerformanceComplexity(data, complexity: .logarithmic)
     }
 
     // - MARK: SquareRoot
 
     func testSquareRootSlopeOne() {
-        let data: BenchmarkData = [(10, 3.16), (20, 4.47), (30, 5.47), (40, 6.32)]
+        let data: Benchmark = [(10, 3.16), (20, 4.47), (30, 5.47), (40, 6.32)]
         assertPerformanceComplexity(data, complexity: .squareRoot)
     }
 
     func testSquareRootSlopeThree() {
-        let data: BenchmarkData = [(10, 9.16), (20, 12.47), (30, 15.47), (40, 18.32)]
+        let data: Benchmark = [(10, 9.16), (20, 12.47), (30, 15.47), (40, 18.32)]
         assertPerformanceComplexity(data, complexity: .squareRoot)
     }
 
     // - MARK: Linear
 
     func testLinearSlopeOne() {
-        let data: BenchmarkData = [(10, 10), (20, 20.5), (30, 29.5), (40, 39.9)]
+        let data: Benchmark = [(10, 10), (20, 20.5), (30, 29.5), (40, 39.9)]
         assertPerformanceComplexity(data, complexity: .linear)
     }
 
     func testLinearSlopeThree() {
-        let data: BenchmarkData = [(10, 30), (20, 61), (30, 85), (40, 121)]
+        let data: Benchmark = [(10, 30), (20, 61), (30, 85), (40, 121)]
         assertPerformanceComplexity(data, complexity: .linear)
     }
 
     // - MARK: Quadratic
 
     func testQuadraticSlopeOne() {
-        let data: BenchmarkData = [(10, 100), (20, 400), (30, 900), (40, 1640)]
+        let data: Benchmark = [(10, 100), (20, 400), (30, 900), (40, 1640)]
         assertPerformanceComplexity(data, complexity: .quadratic)
     }
 
     func testQuadraticSlopeThree() {
-        let data: BenchmarkData = [(10, 300), (20, 1207), (30, 2704), (40, 4805)]
+        let data: Benchmark = [(10, 300), (20, 1207), (30, 2704), (40, 4805)]
         assertPerformanceComplexity(data, complexity: .quadratic)
     }
 
     // - MARK: Cubic
 
     func testCubicSlopeOne() {
-        let data: BenchmarkData = [(10, 1000), (20, 4000), (30, 9000), (40, 16040)]
+        let data: Benchmark = [(10, 1000), (20, 4000), (30, 9000), (40, 16040)]
         assertPerformanceComplexity(data, complexity: .cubic)
     }
 
     func testCubicSlopeThree() {
-        let data: BenchmarkData = [(10, 3000), (20, 12007), (30, 27004), (40, 48050)]
+        let data: Benchmark = [(10, 3000), (20, 12007), (30, 27004), (40, 48050)]
         assertPerformanceComplexity(data, complexity: .cubic)
     }
 
     // - MARK: Exponential
 
     func testExponentialBaseTwoSlopeOne() {
-        let data: BenchmarkData = [(10, 1024), (20, 1e6), (30, 1e9), (40, 1e12)]
+        let data: Benchmark = [(10, 1024), (20, 1e6), (30, 1e9), (40, 1e12)]
         assertPerformanceComplexity(data, complexity: .exponential)
     }
 
     func testExponentialBaseTwoSlopeThree() {
-        let data: BenchmarkData = [(10, 3072), (20, 3e6), (30, 3e9), (40, 3e12)]
+        let data: Benchmark = [(10, 3072), (20, 3e6), (30, 3e9), (40, 3e12)]
         assertPerformanceComplexity(data, complexity: .exponential)
     }
 }

--- a/Tests/PerformanceTestingTests/SetTests.swift
+++ b/Tests/PerformanceTestingTests/SetTests.swift
@@ -13,7 +13,7 @@ class SetTests: PerformanceTestCase {
     /// MARK - Helper functions.
 
     // Constructs a set of size `n` with linearly increasing elements.
-    let constructSizeNSet: SetupFunction<Set<Int>> = { set, n in
+    let constructSizeNSet: SetUp<Set<Int>> = { set, n in
         set.reserveCapacity(Int(n))
         for i in 0..<Int(n) {
             set.insert(i)

--- a/Tests/PerformanceTestingTests/SetTests.swift
+++ b/Tests/PerformanceTestingTests/SetTests.swift
@@ -26,7 +26,7 @@ class SetTests: PerformanceTestCase {
     func testIsEmpty() {
         let data = benchmarkClosure(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setUp: constructSizeNSet,
             trialCode: { set, _ in _ = set.isEmpty },
             isMutating: false
         )
@@ -37,7 +37,7 @@ class SetTests: PerformanceTestCase {
     func testCount() {
         let data = benchmarkClosure(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setUp: constructSizeNSet,
             trialCode: { set, _ in _ = set.count },
             isMutating: false
         )
@@ -48,7 +48,7 @@ class SetTests: PerformanceTestCase {
     func testFirst() {
         let data = benchmarkClosure(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setUp: constructSizeNSet,
             trialCode: { set, _ in _ = set.first },
             isMutating: false
         )
@@ -61,7 +61,7 @@ class SetTests: PerformanceTestCase {
     func testContains() {
         let data = benchmarkClosure(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setUp: constructSizeNSet,
             trialCode: { set, n in
                 let randomNumber = Int(arc4random_uniform(UInt32(n*2)))
                 for _ in 0..<100 {
@@ -79,7 +79,7 @@ class SetTests: PerformanceTestCase {
     func testInsert() {
         let data = benchmarkClosure(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setUp: constructSizeNSet,
             trialCode: { set, n in
                 for _ in 0..<10000 {
                     let randomNumber = Int(arc4random_uniform(UInt32(n*2)))
@@ -97,7 +97,7 @@ class SetTests: PerformanceTestCase {
     func testFilter() {
         let data = benchmarkClosure(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setUp: constructSizeNSet,
             trialCode: { set, n in
                 _ = set.filter { $0 % 5 == 3 }
             },
@@ -110,7 +110,7 @@ class SetTests: PerformanceTestCase {
     func testRemove() {
         let data = benchmarkClosure(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setUp: constructSizeNSet,
             trialCode: { set, n in
                 for _ in 0..<10000 {
                     let randomNumber = Int(arc4random_uniform(UInt32(n*2)))
@@ -126,7 +126,7 @@ class SetTests: PerformanceTestCase {
     func testRemoveFirst() {
         let data = benchmarkClosure(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setUp: constructSizeNSet,
             trialCode: { set, n in
                 _ = set.removeFirst()
             },
@@ -141,7 +141,7 @@ class SetTests: PerformanceTestCase {
     func testUnion() {
         let data = benchmarkClosure(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setUp: constructSizeNSet,
             trialCode: { set, n in
                 _ = set.union(Set.init(0..<300))
             },


### PR DESCRIPTION
In the case of `typealias SetUp<C>`, there was no duplication, so its probably better to just define the type there.

For `Run<C>`, it only happens twice.