### PR TITLE
Refactor to isolate some things into from PerformanceTestCase class

### DIFF
--- a/Sources/PerformanceTesting/Complexity.swift
+++ b/Sources/PerformanceTesting/Complexity.swift
@@ -1,0 +1,44 @@
+//
+//  Complexity.swift
+//  PerformanceTesting
+//
+//  Created by James Bean on 8/10/17.
+//
+
+import Darwin
+
+/// Classes of complexity (big-oh style).
+public enum Complexity {
+
+    case constant
+    case logarithmic
+    case squareRoot
+    case linear
+    case quadratic
+    case cubic
+    case exponential
+    case customComplexity(inverseFunction: (Double) -> Double)
+
+    /// The inverse function of the function represented by this complexity.
+    /// For example, the inverse of squareRoot is squaring.
+    public var inverse: (Double) -> Double {
+        switch self {
+        case .constant:
+            return { $0 }
+        case .logarithmic:
+            return exp
+        case .squareRoot:
+            return { pow($0, 2) }
+        case .linear:
+            return { $0 }
+        case .quadratic:
+            return sqrt
+        case .cubic:
+            return { pow($0, 1/3) }
+        case .exponential:
+            return log
+        case .customComplexity(let inverseFunction):
+            return inverseFunction
+        }
+    }
+}

--- a/Sources/PerformanceTesting/LinearRegression.swift
+++ b/Sources/PerformanceTesting/LinearRegression.swift
@@ -20,10 +20,10 @@ internal func linearRegression(_ data: Benchmark) -> Regression {
 
     let xs = data.map { $0.0 }
     let ys = data.map { $0.1 }
-    let sumOfXs = xs.reduce(0, +)
-    let sumOfYs = ys.reduce(0, +)
-    let sumOfXsSquared = xs.map { pow($0, 2) }.reduce(0, +)
-    let sumOfXsTimesYs = data.map(*).reduce(0, +)
+    let sumOfXs = xs.reduce(0,+)
+    let sumOfYs = ys.reduce(0,+)
+    let sumOfXsSquared = xs.map { pow($0,2) }.reduce(0,+)
+    let sumOfXsTimesYs = data.map(*).reduce(0,+)
 
     let denominator = Double(data.count) * sumOfXsSquared - pow(sumOfXs, 2)
     let interceptNumerator = sumOfYs * sumOfXsSquared - sumOfXs * sumOfXsTimesYs
@@ -48,7 +48,7 @@ private func correlation(
 {
 
     let meanOfYs = sumOfYs / Double(data.count)
-    let squaredErrorOfYs = data.map { pow($0.1 - meanOfYs, 2) }.reduce(0, +)
+    let squaredErrorOfYs = data.map { pow($0.1 - meanOfYs, 2) }.reduce(0,+)
     let denominator = squaredErrorOfYs
 
 //    if Configuration.verbose {
@@ -58,7 +58,7 @@ private func correlation(
     guard denominator != 0 else { return 0 }
 
     let meanOfXs = sumOfXs / Double(data.count)
-    let squaredErrorOfXs = data.map { pow($0.0 - meanOfXs, 2) }.reduce(0, +)
+    let squaredErrorOfXs = data.map { pow($0.0 - meanOfXs, 2) }.reduce(0,+)
     let numerator = squaredErrorOfXs
 
 //    if Configuration.verbose {

--- a/Sources/PerformanceTesting/LinearRegression.swift
+++ b/Sources/PerformanceTesting/LinearRegression.swift
@@ -1,0 +1,72 @@
+//
+//  LinearRegression.swift
+//  PerformanceTesting
+//
+//  Created by James Bean on 8/10/17.
+//
+
+import Darwin
+
+public typealias Benchmark = [(Double, Double)]
+
+internal struct Regression {
+    public let slope: Double
+    public let intercept: Double
+    public let correlation: Double
+}
+
+/// Performs linear regression on the given dataset.
+internal func linearRegression(_ data: Benchmark) -> Regression {
+
+    let xs = data.map { $0.0 }
+    let ys = data.map { $0.1 }
+    let sumOfXs = xs.reduce(0, +)
+    let sumOfYs = ys.reduce(0, +)
+    let sumOfXsSquared = xs.map { pow($0, 2) }.reduce(0, +)
+    let sumOfXsTimesYs = data.map(*).reduce(0, +)
+
+    let denominator = Double(data.count) * sumOfXsSquared - pow(sumOfXs, 2)
+    let interceptNumerator = sumOfYs * sumOfXsSquared - sumOfXs * sumOfXsTimesYs
+    let slopeNumerator = Double(data.count) * sumOfXsTimesYs - sumOfXs * sumOfYs
+
+    let intercept = interceptNumerator / denominator
+    let slope = slopeNumerator / denominator
+
+    let correlation = calculateCorrelation(data,
+       sumOfXs: sumOfXs,
+       sumOfYs: sumOfYs,
+       slope: slope
+    )
+
+    return Regression(slope: slope, intercept: intercept, correlation: correlation)
+}
+
+/// Helper function to calculate the regression coefficient ("r") of the given dataset.
+private func calculateCorrelation(
+    _ data: Benchmark,
+    sumOfXs: Double,
+    sumOfYs: Double,
+    slope: Double
+) -> Double
+{
+
+    let meanOfYs = sumOfYs / Double(data.count)
+    let squaredErrorOfYs = data.map { pow($0.1 - meanOfYs, 2) }.reduce(0, +)
+    let denominator = squaredErrorOfYs
+
+//    if Configuration.verbose {
+//        print("\(#function): denominator: \(denominator)")
+//    }
+
+    guard denominator != 0 else { return 0 }
+
+    let meanOfXs = sumOfXs / Double(data.count)
+    let squaredErrorOfXs = data.map { pow($0.0 - meanOfXs, 2) }.reduce(0, +)
+    let numerator = squaredErrorOfXs
+
+//    if Configuration.verbose {
+//        print("\(#function): numerator: \(numerator)")
+//    }
+
+    return sqrt(numerator / denominator) * slope
+}

--- a/Sources/PerformanceTesting/LinearRegression.swift
+++ b/Sources/PerformanceTesting/LinearRegression.swift
@@ -28,21 +28,18 @@ internal func linearRegression(_ data: Benchmark) -> Regression {
     let denominator = Double(data.count) * sumOfXsSquared - pow(sumOfXs, 2)
     let interceptNumerator = sumOfYs * sumOfXsSquared - sumOfXs * sumOfXsTimesYs
     let slopeNumerator = Double(data.count) * sumOfXsTimesYs - sumOfXs * sumOfYs
-
     let intercept = interceptNumerator / denominator
     let slope = slopeNumerator / denominator
 
-    let correlation = calculateCorrelation(data,
-       sumOfXs: sumOfXs,
-       sumOfYs: sumOfYs,
-       slope: slope
+    return Regression(
+        slope: slope,
+        intercept: intercept,
+        correlation: correlation(data, sumOfXs: sumOfXs, sumOfYs: sumOfYs, slope: slope)
     )
-
-    return Regression(slope: slope, intercept: intercept, correlation: correlation)
 }
 
 /// Helper function to calculate the regression coefficient ("r") of the given dataset.
-private func calculateCorrelation(
+private func correlation(
     _ data: Benchmark,
     sumOfXs: Double,
     sumOfYs: Double,

--- a/Sources/PerformanceTesting/LinearRegression.swift
+++ b/Sources/PerformanceTesting/LinearRegression.swift
@@ -46,24 +46,12 @@ private func correlation(
     slope: Double
 ) -> Double
 {
-
     let meanOfYs = sumOfYs / Double(data.count)
     let squaredErrorOfYs = data.map { pow($0.1 - meanOfYs, 2) }.reduce(0,+)
     let denominator = squaredErrorOfYs
-
-//    if Configuration.verbose {
-//        print("\(#function): denominator: \(denominator)")
-//    }
-
     guard denominator != 0 else { return 0 }
-
     let meanOfXs = sumOfXs / Double(data.count)
     let squaredErrorOfXs = data.map { pow($0.0 - meanOfXs, 2) }.reduce(0,+)
     let numerator = squaredErrorOfXs
-
-//    if Configuration.verbose {
-//        print("\(#function): numerator: \(numerator)")
-//    }
-
     return sqrt(numerator / denominator) * slope
 }

--- a/Sources/PerformanceTesting/LinearRegression.swift
+++ b/Sources/PerformanceTesting/LinearRegression.swift
@@ -39,15 +39,15 @@ internal func linearRegression(_ data: Benchmark) -> Regression {
 }
 
 /// Helper function to calculate the regression coefficient ("r") of the given dataset.
-private func correlation(_ data: Benchmark, sumOfXs: Double, sumOfYs: Double, slope: Double)
+private func correlation(_ benchmark: Benchmark, sumOfXs: Double, sumOfYs: Double, slope: Double)
     -> Double
 {
-    let meanOfYs = sumOfYs / Double(data.count)
-    let squaredErrorOfYs = data.map { pow($0.1 - meanOfYs, 2) }.reduce(0,+)
+    let meanOfYs = sumOfYs / Double(benchmark.count)
+    let squaredErrorOfYs = benchmark.map { pow($0.1 - meanOfYs, 2) }.reduce(0,+)
     let denominator = squaredErrorOfYs
     guard denominator != 0 else { return 0 }
-    let meanOfXs = sumOfXs / Double(data.count)
-    let squaredErrorOfXs = data.map { pow($0.0 - meanOfXs, 2) }.reduce(0,+)
+    let meanOfXs = sumOfXs / Double(benchmark.count)
+    let squaredErrorOfXs = benchmark.map { pow($0.0 - meanOfXs, 2) }.reduce(0,+)
     let numerator = squaredErrorOfXs
     return sqrt(numerator / denominator) * slope
 }

--- a/Sources/PerformanceTesting/LinearRegression.swift
+++ b/Sources/PerformanceTesting/LinearRegression.swift
@@ -39,12 +39,8 @@ internal func linearRegression(_ data: Benchmark) -> Regression {
 }
 
 /// Helper function to calculate the regression coefficient ("r") of the given dataset.
-private func correlation(
-    _ data: Benchmark,
-    sumOfXs: Double,
-    sumOfYs: Double,
-    slope: Double
-) -> Double
+private func correlation(_ data: Benchmark, sumOfXs: Double, sumOfYs: Double, slope: Double)
+    -> Double
 {
     let meanOfYs = sumOfYs / Double(data.count)
     let squaredErrorOfYs = data.map { pow($0.1 - meanOfYs, 2) }.reduce(0,+)

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -43,9 +43,9 @@ open class PerformanceTestCase: XCTestCase {
                 // if the closure is mutating, create a copy before timing the closure
                 if isMutating {
                     var trialMock = pointMock
-                    return time(testPoint: testPoint, mock: &trialMock, measuring: closure);
+                    return time(testPoint: testPoint, mock: &trialMock, measuring: closure)
                 } else {
-                    return time(testPoint: testPoint, mock: &pointMock, measuring: closure);
+                    return time(testPoint: testPoint, mock: &pointMock, measuring: closure)
                 }
             }.reduce(0, +) / Double(trialCount)
             return (testPoint, average)

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -17,6 +17,8 @@ open class PerformanceTestCase: XCTestCase {
 
     // MARK: Nested Types
 
+    // FIXME: Consider making this `DebugLevel`
+    // FIXME: Further, consider making this a global (internal) enum
     public struct Configuration {
         // Controls whether any methods in this file print verbose (debugging) information
         public static var verbose: Bool = true

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -29,7 +29,7 @@ open class PerformanceTestCase: XCTestCase {
     /// Benchmarks the performance of a closure.
     public func benchmark <C> (
         mock object: C,
-        setupFunction: Setup<C>,
+        setup: Setup<C>,
         measuring closure: Run<C>,
         isMutating: Bool,
         testPoints: [Double] = Scale.medium,
@@ -38,7 +38,7 @@ open class PerformanceTestCase: XCTestCase {
     {
         return testPoints.map { point in
             var pointMock = object
-            setupFunction(&pointMock, point)
+            setup(&pointMock, point)
             let average = (0..<trialCount).map { _ in
                 // if the closure is mutating, create a copy before timing the closure
                 if isMutating {

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -43,9 +43,9 @@ open class PerformanceTestCase: XCTestCase {
                 // if the closure is mutating, create a copy before timing the closure
                 if isMutating {
                     var trialMock = pointMock
-                    return time(point: point, mock: &trialMock, measuring: closure);
+                    return time(testPoint: point, mock: &trialMock, measuring: closure);
                 } else {
-                    return time(point: point, mock: &pointMock, measuring: closure);
+                    return time(testPoint: point, mock: &pointMock, measuring: closure);
                 }
             }.reduce(0, +) / Double(trialCount)
             return (point, average)
@@ -53,13 +53,13 @@ open class PerformanceTestCase: XCTestCase {
     }
 
     private func time <C> (
-        point: Double,
+        testPoint: Double,
         mock: inout C,
         measuring closure: Run<C>
     ) -> Double
     {
         let startTime = CFAbsoluteTimeGetCurrent()
-        closure(&mock, point)
+        closure(&mock, testPoint)
         let finishTime = CFAbsoluteTimeGetCurrent()
         return finishTime - startTime
     }

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -117,37 +117,6 @@ open class PerformanceTestCase: XCTestCase {
 
         XCTAssert(results.correlation >= minimumCorrelation)
     }
-
-
-    /// Helper function to calculate the regression coefficient ("r") of the given dataset.
-    private func calculateCorrelation(
-        _ data: Benchmark,
-        sumOfXs: Double,
-        sumOfYs: Double,
-        slope: Double
-        ) -> Double
-    {
-        
-        let meanOfYs = sumOfYs / Double(data.count)
-        let squaredErrorOfYs = data.map { pow($0.1 - meanOfYs, 2) }.reduce(0, +)
-        let denominator = squaredErrorOfYs
-        
-        if Configuration.verbose {
-            print("\(#function): denominator: \(denominator)")
-        }
-        
-        guard denominator != 0 else { return 0 }
-        
-        let meanOfXs = sumOfXs / Double(data.count)
-        let squaredErrorOfXs = data.map { pow($0.0 - meanOfXs, 2) }.reduce(0, +)
-        let numerator = squaredErrorOfXs
-        
-        if Configuration.verbose {
-            print("\(#function): numerator: \(numerator)")
-        }
-        
-        return sqrt(numerator / denominator) * slope
-    }
 }
 
 /// Maps data representing performance of a certain complexity so that it

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -66,15 +66,15 @@ open class PerformanceTestCase: XCTestCase {
 
     /// Assert that the data indicates that performance is constant-time ( O(1) ).
     public func assertConstantTimePerformance(
-        _ data: Benchmark,
+        _ benchmark: Benchmark,
         slopeAccuracy: Double = 0.01
     )
     {
-        let results = linearRegression(data)
+        let results = linearRegression(benchmark)
 
         if Configuration.verbose {
             print("\(#function): data:")
-            for (x, y) in data { print("\t(\(x), \(y))") }
+            for (x, y) in benchmark { print("\t(\(x), \(y))") }
 
             print("\(#function): slope:       \(results.slope)")
             print("\(#function): intercept:   \(results.intercept)")

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -23,14 +23,7 @@ open class PerformanceTestCase: XCTestCase {
         public static var verbose: Bool = true
     }
 
-   
-    /// Ranges of values to use for testPoints (values of `n` in `O(f(n))`).
-    public struct Scale {
-        public static let tiny   = exponentialSeries(size: 10, from: 5,    to: 100)
-        public static let small  = exponentialSeries(size: 10, from: 10,   to: 1_000)
-        public static let medium = exponentialSeries(size: 10, from: 100,  to: 1_000_000)
-        public static let large  = exponentialSeries(size: 10, from: 1000, to: 1_000_000_000)
-    }
+
 
     private struct Regression {
         public let slope: Double
@@ -198,8 +191,4 @@ extension Array where Array == PerformanceTestCase.Benchmark {
     }
 }
 
-// Creates an array of Doubles in an exponential series.
-private func exponentialSeries(size: Int, from start: Double, to end: Double) -> [Double] {
-    let base = pow(end - start + 1, 1 / (Double(size)-1))
-    return (0..<size).map { pow(base, Double($0)) + start - 1 }.map(round)
-}
+

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -14,21 +14,12 @@ open class PerformanceTestCase: XCTestCase {
 
     public typealias Setup<C> = (inout C, Double) -> Void
     public typealias Run<C> = (inout C, Double) -> Void
-    public typealias Benchmark = [(Double, Double)]
 
     // MARK: Nested Types
 
     public struct Configuration {
         // Controls whether any methods in this file print verbose (debugging) information
         public static var verbose: Bool = true
-    }
-
-
-
-    private struct Regression {
-        public let slope: Double
-        public let intercept: Double
-        public let correlation: Double
     }
 
     // MARK: Instance Methods
@@ -125,31 +116,6 @@ open class PerformanceTestCase: XCTestCase {
         XCTAssert(results.correlation >= minimumCorrelation)
     }
 
-    /// Performs linear regression on the given dataset.
-    private func linearRegression(_ data: Benchmark) -> Regression {
-
-        let xs = data.map { $0.0 }
-        let ys = data.map { $0.1 }
-        let sumOfXs = xs.reduce(0, +)
-        let sumOfYs = ys.reduce(0, +)
-        let sumOfXsSquared = xs.map { pow($0, 2) }.reduce(0, +)
-        let sumOfXsTimesYs = data.map(*).reduce(0, +)
-
-        let denominator = Double(data.count) * sumOfXsSquared - pow(sumOfXs, 2)
-        let interceptNumerator = sumOfYs * sumOfXsSquared - sumOfXs * sumOfXsTimesYs
-        let slopeNumerator = Double(data.count) * sumOfXsTimesYs - sumOfXs * sumOfYs
-
-        let intercept = interceptNumerator / denominator
-        let slope = slopeNumerator / denominator
-
-        let correlation = calculateCorrelation(data,
-           sumOfXs: sumOfXs,
-           sumOfYs: sumOfYs,
-           slope: slope
-        )
-
-        return Regression(slope: slope, intercept: intercept, correlation: correlation)
-    }
 
     /// Helper function to calculate the regression coefficient ("r") of the given dataset.
     private func calculateCorrelation(
@@ -157,27 +123,27 @@ open class PerformanceTestCase: XCTestCase {
         sumOfXs: Double,
         sumOfYs: Double,
         slope: Double
-    ) -> Double
+        ) -> Double
     {
-
+        
         let meanOfYs = sumOfYs / Double(data.count)
         let squaredErrorOfYs = data.map { pow($0.1 - meanOfYs, 2) }.reduce(0, +)
         let denominator = squaredErrorOfYs
-
+        
         if Configuration.verbose {
             print("\(#function): denominator: \(denominator)")
         }
-
+        
         guard denominator != 0 else { return 0 }
-
+        
         let meanOfXs = sumOfXs / Double(data.count)
         let squaredErrorOfXs = data.map { pow($0.0 - meanOfXs, 2) }.reduce(0, +)
         let numerator = squaredErrorOfXs
-
+        
         if Configuration.verbose {
             print("\(#function): numerator: \(numerator)")
         }
-
+        
         return sqrt(numerator / denominator) * slope
     }
 }
@@ -185,10 +151,8 @@ open class PerformanceTestCase: XCTestCase {
 /// Maps data representing performance of a certain complexity so that it
 /// can be fit with linear regression. This is done by applying the inverse
 /// function of the expected performance function.
-extension Array where Array == PerformanceTestCase.Benchmark {
+extension Array where Array == Benchmark {
     public func mappedForLinearFit(complexity: Complexity) -> Array {
         return self.map { ($0, complexity.inverse($1)) }
     }
 }
-
-

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -36,19 +36,19 @@ open class PerformanceTestCase: XCTestCase {
         trialCount: Int = 10
     ) -> Benchmark
     {
-        return testPoints.map { point in
+        return testPoints.map { testPoint in
             var pointMock = object
-            setup(&pointMock, point)
+            setup(&pointMock, testPoint)
             let average = (0..<trialCount).map { _ in
                 // if the closure is mutating, create a copy before timing the closure
                 if isMutating {
                     var trialMock = pointMock
-                    return time(testPoint: point, mock: &trialMock, measuring: closure);
+                    return time(testPoint: testPoint, mock: &trialMock, measuring: closure);
                 } else {
-                    return time(testPoint: point, mock: &pointMock, measuring: closure);
+                    return time(testPoint: testPoint, mock: &pointMock, measuring: closure);
                 }
             }.reduce(0, +) / Double(trialCount)
-            return (point, average)
+            return (testPoint, average)
         }
     }
 

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -23,42 +23,7 @@ open class PerformanceTestCase: XCTestCase {
         public static var verbose: Bool = true
     }
 
-    /// Classes of complexity (big-oh style).
-    public enum Complexity {
-
-        case constant
-        case logarithmic
-        case squareRoot
-        case linear
-        case quadratic
-        case cubic
-        case exponential
-        case customComplexity(inverseFunction: (Double) -> Double)
-
-        /// The inverse function of the function represented by this complexity.
-        /// For example, the inverse of squareRoot is squaring.
-        public var inverse: (Double) -> Double {
-            switch self {
-            case .constant:
-                return { $0 }
-            case .logarithmic:
-                return exp
-            case .squareRoot:
-                return { pow($0, 2) }
-            case .linear:
-                return { $0 }
-            case .quadratic:
-                return sqrt
-            case .cubic:
-                return { pow($0, 1/3) }
-            case .exponential:
-                return log
-            case .customComplexity(let inverseFunction):
-                return inverseFunction
-            }
-        }
-    }
-
+   
     /// Ranges of values to use for testPoints (values of `n` in `O(f(n))`).
     public struct Scale {
         public static let tiny   = exponentialSeries(size: 10, from: 5,    to: 100)
@@ -228,7 +193,7 @@ open class PerformanceTestCase: XCTestCase {
 /// can be fit with linear regression. This is done by applying the inverse
 /// function of the expected performance function.
 extension Array where Array == PerformanceTestCase.Benchmark {
-    public func mappedForLinearFit(complexity: PerformanceTestCase.Complexity) -> Array {
+    public func mappedForLinearFit(complexity: Complexity) -> Array {
         return self.map { ($0, complexity.inverse($1)) }
     }
 }

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -52,18 +52,6 @@ open class PerformanceTestCase: XCTestCase {
         }
     }
 
-    private func time <C> (
-        testPoint: Double,
-        mock: inout C,
-        measuring closure: Run<C>
-    ) -> Double
-    {
-        let startTime = CFAbsoluteTimeGetCurrent()
-        closure(&mock, testPoint)
-        let finishTime = CFAbsoluteTimeGetCurrent()
-        return finishTime - startTime
-    }
-
     /// Assert that the data indicates that performance is constant-time ( O(1) ).
     public func assertConstantTimePerformance(
         _ benchmark: Benchmark,
@@ -116,6 +104,18 @@ open class PerformanceTestCase: XCTestCase {
         }
 
         XCTAssert(results.correlation >= minimumCorrelation)
+    }
+
+    private func time <C> (
+        testPoint: Double,
+        mock: inout C,
+        measuring closure: Run<C>
+    ) -> Double
+    {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        closure(&mock, testPoint)
+        let finishTime = CFAbsoluteTimeGetCurrent()
+        return finishTime - startTime
     }
 }
 

--- a/Sources/PerformanceTesting/Scale.swift
+++ b/Sources/PerformanceTesting/Scale.swift
@@ -1,0 +1,22 @@
+//
+//  Scale.swift
+//  PerformanceTesting
+//
+//  Created by James Bean on 8/10/17.
+//
+
+import Darwin
+
+/// Ranges of values to use for testPoints (values of `n` in `O(f(n))`).
+public struct Scale {
+    public static let tiny   = exponentialSeries(size: 10, from: 5,    to: 100)
+    public static let small  = exponentialSeries(size: 10, from: 10,   to: 1_000)
+    public static let medium = exponentialSeries(size: 10, from: 100,  to: 1_000_000)
+    public static let large  = exponentialSeries(size: 10, from: 1000, to: 1_000_000_000)
+}
+
+// Creates an array of Doubles in an exponential series.
+private func exponentialSeries(size: Int, from start: Double, to end: Double) -> [Double] {
+    let base = pow(end - start + 1, 1 / (Double(size)-1))
+    return (0..<size).map { pow(base, Double($0)) + start - 1 }.map(round)
+}

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -35,7 +35,7 @@ class ArrayTests: PerformanceTestCase {
     func testIsEmpty() {
         let data = benchmark(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setup: constructSizeNArray,
             measuring: { array, _ in _ = array.isEmpty },
             isMutating: false
         )
@@ -46,7 +46,7 @@ class ArrayTests: PerformanceTestCase {
     func testCount() {
         let data = benchmark(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setup: constructSizeNArray,
             measuring: { array, _ in _ = array.count },
             isMutating: false
         )
@@ -59,7 +59,7 @@ class ArrayTests: PerformanceTestCase {
     func testSubscript() {
         let data = benchmark(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setup: constructSizeNArray,
             measuring: { array, _ in _ = array[3] },
             isMutating: false
         )
@@ -70,7 +70,7 @@ class ArrayTests: PerformanceTestCase {
     func testFirst() {
         let data = benchmark(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setup: constructSizeNArray,
             measuring: { array, _ in _ = array.first },
             isMutating: false
         )
@@ -81,7 +81,7 @@ class ArrayTests: PerformanceTestCase {
     func testLast() {
         let data = benchmark(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setup: constructSizeNArray,
             measuring: { array, _ in _ = array.last },
             isMutating: false
         )
@@ -94,7 +94,7 @@ class ArrayTests: PerformanceTestCase {
     func testAppend() {
         let data = benchmark(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setup: constructSizeNArray,
             measuring: { array, _ in array.append(6) },
             isMutating: true
         )
@@ -105,7 +105,7 @@ class ArrayTests: PerformanceTestCase {
     func testInsert() {
         let data = benchmark(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setup: constructSizeNArray,
             measuring: { array, _ in
                 for _ in 0..<100 {
                     array.insert(6, at: 0)
@@ -122,7 +122,7 @@ class ArrayTests: PerformanceTestCase {
     func testRemove() {
         let data = benchmark(
             mock: [],
-            setupFunction: constructSizeNArray,
+            setup: constructSizeNArray,
             measuring: { array, n in
                 for _ in 0..<100 {
                     _ = array.remove(at: 0)
@@ -141,7 +141,7 @@ class ArrayTests: PerformanceTestCase {
     func testSort() {
         let data = benchmark(
             mock: [],
-            setupFunction: constructRandomSizeNArray,
+            setup: constructRandomSizeNArray,
             measuring: { array, n in
                 array.sort()
             },
@@ -154,7 +154,7 @@ class ArrayTests: PerformanceTestCase {
     func testPartition() {
         let data = benchmark(
             mock: [],
-            setupFunction: constructRandomSizeNArray,
+            setup: constructRandomSizeNArray,
             measuring: { array, n in
                 _ = array.partition { element in element > 50 }
             },

--- a/Tests/PerformanceTestingTests/SetTests.swift
+++ b/Tests/PerformanceTestingTests/SetTests.swift
@@ -26,7 +26,7 @@ class SetTests: PerformanceTestCase {
     func testIsEmpty() {
         let data = benchmark(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setup: constructSizeNSet,
             measuring: { set, _ in _ = set.isEmpty },
             isMutating: false
         )
@@ -37,7 +37,7 @@ class SetTests: PerformanceTestCase {
     func testCount() {
         let data = benchmark(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setup: constructSizeNSet,
             measuring: { set, _ in _ = set.count },
             isMutating: false
         )
@@ -48,7 +48,7 @@ class SetTests: PerformanceTestCase {
     func testFirst() {
         let data = benchmark(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setup: constructSizeNSet,
             measuring: { set, _ in _ = set.first },
             isMutating: false
         )
@@ -61,7 +61,7 @@ class SetTests: PerformanceTestCase {
     func testContains() {
         let data = benchmark(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setup: constructSizeNSet,
             measuring: { set, n in
                 let randomNumber = Int(arc4random_uniform(UInt32(n*2)))
                 for _ in 0..<100 {
@@ -79,7 +79,7 @@ class SetTests: PerformanceTestCase {
     func testInsert() {
         let data = benchmark(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setup: constructSizeNSet,
             measuring: { set, n in
                 for _ in 0..<10000 {
                     let randomNumber = Int(arc4random_uniform(UInt32(n*2)))
@@ -97,7 +97,7 @@ class SetTests: PerformanceTestCase {
     func testFilter() {
         let data = benchmark(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setup: constructSizeNSet,
             measuring: { set, n in
                 _ = set.filter { $0 % 5 == 3 }
             },
@@ -110,7 +110,7 @@ class SetTests: PerformanceTestCase {
     func testRemove() {
         let data = benchmark(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setup: constructSizeNSet,
             measuring: { set, n in
                 for _ in 0..<10000 {
                     let randomNumber = Int(arc4random_uniform(UInt32(n*2)))
@@ -126,7 +126,7 @@ class SetTests: PerformanceTestCase {
     func testRemoveFirst() {
         let data = benchmark(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setup: constructSizeNSet,
             measuring: { set, n in
                 _ = set.removeFirst()
             },
@@ -141,7 +141,7 @@ class SetTests: PerformanceTestCase {
     func testUnion() {
         let data = benchmark(
             mock: Set.init(),
-            setupFunction: constructSizeNSet,
+            setup: constructSizeNSet,
             measuring: { set, n in
                 _ = set.union(Set.init(0..<300))
             },


### PR DESCRIPTION
This PR is a little refactor which explodes out some helper functions and structures from the `PerformanceTestCase`.

Within `correlation`, these meant killing the logging (though this can be temporary).

Some things are now `internal`, instead of `private`, though I would argue this isn't changing their nature too much. The module is still sealed for these things.