### PR TITLE
Rename C -> Structure, mock -> structure

### DIFF
--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -12,8 +12,8 @@ open class PerformanceTestCase: XCTestCase {
 
     // MARK: Associated Types
 
-    public typealias Setup<C> = (inout C, Double) -> Void
-    public typealias Operation<C> = (inout C, Double) -> Void
+    public typealias Setup <Structure> = (inout Structure, Double) -> Void
+    public typealias Operation <Structure> = (inout Structure, Double) -> Void
 
     // MARK: Nested Types
 
@@ -27,10 +27,10 @@ open class PerformanceTestCase: XCTestCase {
     // MARK: Instance Methods
 
     /// Benchmarks the performance of a closure.
-    public func benchmark <C> (
-        mock object: C,
-        setup: Setup<C>,
-        measuring operation: Operation<C>,
+    public func benchmark <Structure> (
+        mock object: Structure,
+        setup: Setup<Structure>,
+        measuring operation: Operation<Structure>,
         isMutating: Bool,
         testPoints: [Double] = Scale.medium,
         trialCount: Int = 10
@@ -106,10 +106,10 @@ open class PerformanceTestCase: XCTestCase {
         XCTAssert(results.correlation >= minimumCorrelation)
     }
 
-    private func time <C> (
+    private func time <Structure> (
         testPoint: Double,
-        mock: inout C,
-        measuring operation: Operation<C>
+        mock: inout Structure,
+        measuring operation: Operation<Structure>
     ) -> Double
     {
         let startTime = CFAbsoluteTimeGetCurrent()

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -37,15 +37,15 @@ open class PerformanceTestCase: XCTestCase {
     ) -> Benchmark
     {
         return testPoints.map { testPoint in
-            var pointMock = structure
-            setup(&pointMock, testPoint)
+            var testPointCopy = structure
+            setup(&testPointCopy, testPoint)
             let average = (0..<trialCount).map { _ in
                 // if the closure is mutating, create a copy before timing the closure
                 if isMutating {
-                    var trialMock = pointMock
-                    return time(testPoint: testPoint, structure: &trialMock, measuring: operation)
+                    var trialCopy = testPointCopy
+                    return time(testPoint: testPoint, structure: &trialCopy, measuring: operation)
                 } else {
-                    return time(testPoint: testPoint, structure: &pointMock, measuring: operation)
+                    return time(testPoint: testPoint, structure: &testPointCopy, measuring: operation)
                 }
             }.reduce(0, +) / Double(trialCount)
             return (testPoint, average)

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -28,7 +28,7 @@ open class PerformanceTestCase: XCTestCase {
 
     /// Benchmarks the performance of a closure.
     public func benchmark <Structure> (
-        mock object: Structure,
+        structure: Structure,
         setup: Setup<Structure>,
         measuring operation: Operation<Structure>,
         isMutating: Bool,
@@ -37,7 +37,7 @@ open class PerformanceTestCase: XCTestCase {
     ) -> Benchmark
     {
         return testPoints.map { testPoint in
-            var pointMock = object
+            var pointMock = structure
             setup(&pointMock, testPoint)
             let average = (0..<trialCount).map { _ in
                 // if the closure is mutating, create a copy before timing the closure

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -43,9 +43,9 @@ open class PerformanceTestCase: XCTestCase {
                 // if the closure is mutating, create a copy before timing the closure
                 if isMutating {
                     var trialMock = pointMock
-                    return time(testPoint: testPoint, mock: &trialMock, measuring: operation)
+                    return time(testPoint: testPoint, structure: &trialMock, measuring: operation)
                 } else {
-                    return time(testPoint: testPoint, mock: &pointMock, measuring: operation)
+                    return time(testPoint: testPoint, structure: &pointMock, measuring: operation)
                 }
             }.reduce(0, +) / Double(trialCount)
             return (testPoint, average)
@@ -108,12 +108,12 @@ open class PerformanceTestCase: XCTestCase {
 
     private func time <Structure> (
         testPoint: Double,
-        mock: inout Structure,
+        structure: inout Structure,
         measuring operation: Operation<Structure>
     ) -> Double
     {
         let startTime = CFAbsoluteTimeGetCurrent()
-        operation(&mock, testPoint)
+        operation(&structure, testPoint)
         let finishTime = CFAbsoluteTimeGetCurrent()
         return finishTime - startTime
     }

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -34,7 +34,7 @@ class ArrayTests: PerformanceTestCase {
     // `isEmpty` should be constant-time in the number of elements
     func testIsEmpty() {
         let data = benchmark(
-            mock: [],
+            structure: [],
             setup: constructSizeNArray,
             measuring: { array, _ in _ = array.isEmpty },
             isMutating: false
@@ -45,7 +45,7 @@ class ArrayTests: PerformanceTestCase {
     // `count` should be constant-time in the number of elements
     func testCount() {
         let data = benchmark(
-            mock: [],
+            structure: [],
             setup: constructSizeNArray,
             measuring: { array, _ in _ = array.count },
             isMutating: false
@@ -58,7 +58,7 @@ class ArrayTests: PerformanceTestCase {
     // `subscript` should be constant-time in the number of elements
     func testSubscript() {
         let data = benchmark(
-            mock: [],
+            structure: [],
             setup: constructSizeNArray,
             measuring: { array, _ in _ = array[3] },
             isMutating: false
@@ -69,7 +69,7 @@ class ArrayTests: PerformanceTestCase {
     // `first` should be constant-time in the number of elements
     func testFirst() {
         let data = benchmark(
-            mock: [],
+            structure: [],
             setup: constructSizeNArray,
             measuring: { array, _ in _ = array.first },
             isMutating: false
@@ -80,7 +80,7 @@ class ArrayTests: PerformanceTestCase {
     // `last` should be constant-time in the number of elements
     func testLast() {
         let data = benchmark(
-            mock: [],
+            structure: [],
             setup: constructSizeNArray,
             measuring: { array, _ in _ = array.last },
             isMutating: false
@@ -93,7 +93,7 @@ class ArrayTests: PerformanceTestCase {
     // `append` should be (amortized) constant-time in the number of elements
     func testAppend() {
         let data = benchmark(
-            mock: [],
+            structure: [],
             setup: constructSizeNArray,
             measuring: { array, _ in array.append(6) },
             isMutating: true
@@ -104,7 +104,7 @@ class ArrayTests: PerformanceTestCase {
     // `insert` should be O(n) in the number of elements
     func testInsert() {
         let data = benchmark(
-            mock: [],
+            structure: [],
             setup: constructSizeNArray,
             measuring: { array, _ in
                 for _ in 0..<100 {
@@ -121,7 +121,7 @@ class ArrayTests: PerformanceTestCase {
     // `remove` should be O(n) in the number of elements
     func testRemove() {
         let data = benchmark(
-            mock: [],
+            structure: [],
             setup: constructSizeNArray,
             measuring: { array, n in
                 for _ in 0..<100 {
@@ -140,7 +140,7 @@ class ArrayTests: PerformanceTestCase {
     // a line to it well enough.
     func testSort() {
         let data = benchmark(
-            mock: [],
+            structure: [],
             setup: constructRandomSizeNArray,
             measuring: { array, n in
                 array.sort()
@@ -153,7 +153,7 @@ class ArrayTests: PerformanceTestCase {
     // `partition` should be O(n) in the number of elements
     func testPartition() {
         let data = benchmark(
-            mock: [],
+            structure: [],
             setup: constructRandomSizeNArray,
             measuring: { array, n in
                 _ = array.partition { element in element > 50 }

--- a/Tests/PerformanceTestingTests/SetTests.swift
+++ b/Tests/PerformanceTestingTests/SetTests.swift
@@ -25,7 +25,7 @@ class SetTests: PerformanceTestCase {
     // `isEmpty` should be constant-time in the number of elements
     func testIsEmpty() {
         let data = benchmark(
-            mock: Set.init(),
+            structure: Set.init(),
             setup: constructSizeNSet,
             measuring: { set, _ in _ = set.isEmpty },
             isMutating: false
@@ -36,7 +36,7 @@ class SetTests: PerformanceTestCase {
     // `count` should be constant-time in the number of elements
     func testCount() {
         let data = benchmark(
-            mock: Set.init(),
+            structure: Set.init(),
             setup: constructSizeNSet,
             measuring: { set, _ in _ = set.count },
             isMutating: false
@@ -47,7 +47,7 @@ class SetTests: PerformanceTestCase {
     // `first` should be constant-time in the number of elements
     func testFirst() {
         let data = benchmark(
-            mock: Set.init(),
+            structure: Set.init(),
             setup: constructSizeNSet,
             measuring: { set, _ in _ = set.first },
             isMutating: false
@@ -60,7 +60,7 @@ class SetTests: PerformanceTestCase {
     // `contains` should be constant-time in the number of elements
     func testContains() {
         let data = benchmark(
-            mock: Set.init(),
+            structure: Set.init(),
             setup: constructSizeNSet,
             measuring: { set, n in
                 let randomNumber = Int(arc4random_uniform(UInt32(n*2)))
@@ -78,7 +78,7 @@ class SetTests: PerformanceTestCase {
     // `insert` should be constant-time in the number of elements
     func testInsert() {
         let data = benchmark(
-            mock: Set.init(),
+            structure: Set.init(),
             setup: constructSizeNSet,
             measuring: { set, n in
                 for _ in 0..<10000 {
@@ -96,7 +96,7 @@ class SetTests: PerformanceTestCase {
     // `filter` should be linear in the number of elements
     func testFilter() {
         let data = benchmark(
-            mock: Set.init(),
+            structure: Set.init(),
             setup: constructSizeNSet,
             measuring: { set, n in
                 _ = set.filter { $0 % 5 == 3 }
@@ -109,7 +109,7 @@ class SetTests: PerformanceTestCase {
     // `remove` should be constant-time in the number of elements
     func testRemove() {
         let data = benchmark(
-            mock: Set.init(),
+            structure: Set.init(),
             setup: constructSizeNSet,
             measuring: { set, n in
                 for _ in 0..<10000 {
@@ -125,7 +125,7 @@ class SetTests: PerformanceTestCase {
     // `removeFirst` should be constant-time in the number of elements
     func testRemoveFirst() {
         let data = benchmark(
-            mock: Set.init(),
+            structure: Set.init(),
             setup: constructSizeNSet,
             measuring: { set, n in
                 _ = set.removeFirst()
@@ -140,7 +140,7 @@ class SetTests: PerformanceTestCase {
     // `union` should be linear in the number of elements inserted
     func testUnion() {
         let data = benchmark(
-            mock: Set.init(),
+            structure: Set.init(),
             setup: constructSizeNSet,
             measuring: { set, n in
                 _ = set.union(Set.init(0..<300))


### PR DESCRIPTION
The generic parameter `C` is littered all over the place, and even sometimes it takes me a few ms too long to reason about what it is.

I chose `Structure`, but perhaps this could be anything.

Further, I unified the name of the argument label from `mock` to `structure` to unify this a bit more.

I propose to step away from the usage of `mock`. AFAIK, this is an OOP concept constructed to compensate for unruly state. In this case, we aren't mocking anything to do so. Instead, we are just passing around the real thing.

We can def discuss, as my knowledge of the concept isn't super rich.