### PR TITLE
[WIP / Do Not Merge] Flesh out Benchmark model

### DIFF
--- a/Sources/PerformanceTesting/Benchmark.swift
+++ b/Sources/PerformanceTesting/Benchmark.swift
@@ -5,25 +5,17 @@
 //  Created by James Bean on 8/11/17.
 //
 
+/// Structure containing one or more tests of a single operation over varying input sizes.
+//
+// TODO: Add structure name info
+// TODO: Add operation info
 public struct Benchmark {
+
+    /// Array of two-tuples containing inputSize and average performance time.
     var data: [(Double,Double)] {
-        return tests.map { test in (Double(test.size), test.average) }
-    }
-    let tests: [PerformanceTest]
-}
-
-/// Storage of the size of a structure, and the amounts of time taken to perform each trial.
-public struct PerformanceTest {
-
-    public var average: Double {
-        return results.average
+        return tests.map { test in (Double(test.inputSize), test.average) }
     }
 
-    // FIXME: Add meta data (structure name, operation name)
-
-    /// The size of the structure over which an operation is performed.
-    let size: Int
-
-    /// The amount of time it took to perform each trial.
-    let results: [Trial]
+    /// Results of tests of an operation over a single input size.
+    let tests: [Test]
 }

--- a/Sources/PerformanceTesting/Benchmark.swift
+++ b/Sources/PerformanceTesting/Benchmark.swift
@@ -5,4 +5,6 @@
 //  Created by James Bean on 8/11/17.
 //
 
-public typealias Benchmark = [(Double, Double)]
+public typealias TestPoint = (Double,Trial)
+
+public typealias Benchmark = [TestPoint]

--- a/Sources/PerformanceTesting/Benchmark.swift
+++ b/Sources/PerformanceTesting/Benchmark.swift
@@ -5,6 +5,25 @@
 //  Created by James Bean on 8/11/17.
 //
 
-public typealias TestPoint = (Double,Trial)
+public struct Benchmark {
+    var data: [(Double,Double)] {
+        return tests.map { test in (Double(test.size), test.average) }
+    }
+    let tests: [PerformanceTest]
+}
 
-public typealias Benchmark = [TestPoint]
+/// Storage of the size of a structure, and the amounts of time taken to perform each trial.
+public struct PerformanceTest {
+
+    public var average: Double {
+        return results.average
+    }
+
+    // FIXME: Add meta data (structure name, operation name)
+
+    /// The size of the structure over which an operation is performed.
+    let size: Int
+
+    /// The amount of time it took to perform each trial.
+    let results: [Trial]
+}

--- a/Sources/PerformanceTesting/LinearRegression.swift
+++ b/Sources/PerformanceTesting/LinearRegression.swift
@@ -13,7 +13,7 @@ internal struct Regression {
     public let correlation: Double
 }
 
-/// Performs linear regression on the given dataset.
+/// - Returns: `Regression` info for the given dataset (two-tuple of x,y pairs).
 internal func linearRegression(_ data: [(Double,Double)]) -> Regression {
 
     let xs = data.map { $0.0 }

--- a/Sources/PerformanceTesting/LinearRegression.swift
+++ b/Sources/PerformanceTesting/LinearRegression.swift
@@ -14,7 +14,7 @@ internal struct Regression {
 }
 
 /// Performs linear regression on the given dataset.
-internal func linearRegression(_ data: Benchmark) -> Regression {
+internal func linearRegression(_ data: [(Double,Double)]) -> Regression {
 
     let xs = data.map { $0.0 }
     let ys = data.map { $0.1 }
@@ -37,15 +37,15 @@ internal func linearRegression(_ data: Benchmark) -> Regression {
 }
 
 /// Helper function to calculate the regression coefficient ("r") of the given dataset.
-private func correlation(_ benchmark: Benchmark, sumOfXs: Double, sumOfYs: Double, slope: Double)
+private func correlation(_ data: [(Double,Double)], sumOfXs: Double, sumOfYs: Double, slope: Double)
     -> Double
 {
-    let meanOfYs = sumOfYs / Double(benchmark.count)
-    let squaredErrorOfYs = benchmark.map { pow($0.1 - meanOfYs, 2) }.reduce(0,+)
+    let meanOfYs = sumOfYs / Double(data.count)
+    let squaredErrorOfYs = data.map { pow($0.1 - meanOfYs, 2) }.reduce(0,+)
     let denominator = squaredErrorOfYs
     guard denominator != 0 else { return 0 }
-    let meanOfXs = sumOfXs / Double(benchmark.count)
-    let squaredErrorOfXs = benchmark.map { pow($0.0 - meanOfXs, 2) }.reduce(0,+)
+    let meanOfXs = sumOfXs / Double(data.count)
+    let squaredErrorOfXs = data.map { pow($0.0 - meanOfXs, 2) }.reduce(0,+)
     let numerator = squaredErrorOfXs
     return sqrt(numerator / denominator) * slope
 }

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -26,24 +26,29 @@ open class PerformanceTestCase: XCTestCase {
 
     // MARK: Instance Methods
 
-    /// - Returns: An array of two-tuples containing the size of the structure and the average time
-    /// taken to perform the given `operation`.
+    /// - Parameters:
+    ///   - structure: The structure on which we perform the given `operation`
+    ///   - setup: Preparation of structure which is not measured
+    ///   - operation: The operation to be measures
+    ///   - inputSizes: Array of input sizes for which to measure the given `operation`
+    ///   - trialCount: The amount of trials to be performed for each input size
+    /// - Returns: `Benchmark`
     public func benchmark <Structure> (
         structure: Structure,
         setup: Setup<Structure>,
         measuring operation: Operation<Structure>,
-        testPoints: [Double] = Scale.medium,
+        inputSizes: [Double] = Scale.medium,
         trialCount: Int = 10
     ) -> Benchmark
     {
-        let tests: [PerformanceTest] = testPoints.map { testPoint in
+        let tests: [Test] = inputSizes.map { testPoint in
             var testPointCopy = structure
             setup(&testPointCopy, testPoint)
             let results: [Double] = (0..<trialCount).map { _ in
                 var trialCopy = testPointCopy
                 return measure(operation, on: &trialCopy, for: testPoint)
             }
-            return PerformanceTest(size: Int(testPoint), results: results)
+            return Test(inputSize: Int(testPoint), results: results)
         }
         return Benchmark(tests: tests)
     }

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -115,11 +115,11 @@ open class PerformanceTestCase: XCTestCase {
     private func measure <Structure> (
         _ operation: Operation<Structure>,
         on structure: inout Structure,
-        for testPoint: Double
+        for inputSize: Double
     ) -> Double
     {
         let startTime = CFAbsoluteTimeGetCurrent()
-        operation(&structure, testPoint)
+        operation(&structure, inputSize)
         let finishTime = CFAbsoluteTimeGetCurrent()
         return finishTime - startTime
     }

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -29,7 +29,7 @@ open class PerformanceTestCase: XCTestCase {
     /// - Parameters:
     ///   - structure: The structure on which we perform the given `operation`
     ///   - setup: Preparation of structure which is not measured
-    ///   - operation: The operation to be measures
+    ///   - operation: The operation to be measured
     ///   - inputSizes: Array of input sizes for which to measure the given `operation`
     ///   - trialCount: The amount of trials to be performed for each input size
     /// - Returns: `Benchmark`

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -41,14 +41,14 @@ open class PerformanceTestCase: XCTestCase {
         trialCount: Int = 10
     ) -> Benchmark
     {
-        let tests: [Test] = inputSizes.map { testPoint in
+        let tests: [Test] = inputSizes.map { inputSize in
             var testPointCopy = structure
-            setup(&testPointCopy, testPoint)
+            setup(&testPointCopy, inputSize)
             let results: [Double] = (0..<trialCount).map { _ in
                 var trialCopy = testPointCopy
-                return measure(operation, on: &trialCopy, for: testPoint)
+                return measure(operation, on: &trialCopy, for: inputSize)
             }
-            return Test(inputSize: Int(testPoint), results: results)
+            return Test(inputSize: Int(inputSize), results: results)
         }
         return Benchmark(tests: tests)
     }

--- a/Sources/PerformanceTesting/Test.swift
+++ b/Sources/PerformanceTesting/Test.swift
@@ -1,0 +1,22 @@
+//
+//  Test.swift
+//  PerformanceTesting
+//
+//  Created by James Bean on 8/11/17.
+//
+
+/// Representation of a test of a single operation over a given `inputSize`. This test may have been
+/// run multiple times, the measurements of which are stored in `results`.
+public struct Test {
+
+    /// Average amount of time to complete a given operation of the `inputSize`.
+    public var average: Double {
+        return results.average
+    }
+
+    /// The size of the input over which an operation is performed.
+    let inputSize: Int
+
+    /// The amount of time it took to perform each trial.
+    let results: [Double]
+}

--- a/Sources/PerformanceTesting/Trial.swift
+++ b/Sources/PerformanceTesting/Trial.swift
@@ -1,0 +1,9 @@
+//
+//  Trial.swift
+//  PerformanceTesting
+//
+//  Created by James Bean on 8/11/17.
+//
+
+/// The amount of time it took to perform an operation over a structure.
+public typealias Trial = Double

--- a/Sources/PerformanceTesting/Trial.swift
+++ b/Sources/PerformanceTesting/Trial.swift
@@ -1,9 +1,0 @@
-//
-//  Trial.swift
-//  PerformanceTesting
-//
-//  Created by James Bean on 8/11/17.
-//
-
-/// The amount of time it took to perform an operation over a structure.
-public typealias Trial = Double

--- a/Tests/PerformanceTestingTests/ComplexityTests.swift
+++ b/Tests/PerformanceTestingTests/ComplexityTests.swift
@@ -16,89 +16,89 @@ class PerformanceTestingTests: PerformanceTestCase {
     // MARK: Constant
 
     func testConstant() {
-        let data: Benchmark = [(1, 1.01), (2, 1.01), (3, 1.05), (4, 0.99)]
+        let data: [(Double,Double)] = [(1, 1.01), (2, 1.01), (3, 1.05), (4, 0.99)]
         assertConstantTimePerformance(data)
     }
 
     // MARK: Logarithmic
 
     func testLogarithmicBaseTwoSlopeOne() {
-        let data: Benchmark = [(10, 3.32), (20, 4.32), (30, 4.91), (40, 5.32)]
+        let data: [(Double,Double)] = [(10, 3.32), (20, 4.32), (30, 4.91), (40, 5.32)]
         assertPerformanceComplexity(data, complexity: .logarithmic)
     }
 
     func testLogarithmicBaseTwoSlopeThree() {
-        let data: Benchmark = [(10, 4.90), (20, 5.91), (30, 6.49), (40, 6.90)]
+        let data: [(Double,Double)] = [(10, 4.90), (20, 5.91), (30, 6.49), (40, 6.90)]
         assertPerformanceComplexity(data, complexity: .logarithmic)
     }
 
     func testLogarithmicBaseESlopeOne() {
-        let data: Benchmark = [(10, 2.30), (20, 2.99), (30, 3.40), (40, 3.69)]
+        let data: [(Double,Double)] = [(10, 2.30), (20, 2.99), (30, 3.40), (40, 3.69)]
         assertPerformanceComplexity(data, complexity: .logarithmic)
     }
 
     func testLogarithmicBaseESlopeThree() {
-        let data: Benchmark = [(10, 3.40), (20, 4.09), (30, 4.50), (40, 4.79)]
+        let data: [(Double,Double)] = [(10, 3.40), (20, 4.09), (30, 4.50), (40, 4.79)]
         assertPerformanceComplexity(data, complexity: .logarithmic)
     }
 
     // MARK: SquareRoot
 
     func testSquareRootSlopeOne() {
-        let data: Benchmark = [(10, 3.16), (20, 4.47), (30, 5.47), (40, 6.32)]
+        let data: [(Double,Double)] = [(10, 3.16), (20, 4.47), (30, 5.47), (40, 6.32)]
         assertPerformanceComplexity(data, complexity: .squareRoot)
     }
 
     func testSquareRootSlopeThree() {
-        let data: Benchmark = [(10, 9.16), (20, 12.47), (30, 15.47), (40, 18.32)]
+        let data: [(Double,Double)] = [(10, 9.16), (20, 12.47), (30, 15.47), (40, 18.32)]
         assertPerformanceComplexity(data, complexity: .squareRoot)
     }
 
     // MARK: Linear
 
     func testLinearSlopeOne() {
-        let data: Benchmark = [(10, 10), (20, 20.5), (30, 29.5), (40, 39.9)]
+        let data: [(Double,Double)] = [(10, 10), (20, 20.5), (30, 29.5), (40, 39.9)]
         assertPerformanceComplexity(data, complexity: .linear)
     }
 
     func testLinearSlopeThree() {
-        let data: Benchmark = [(10, 30), (20, 61), (30, 85), (40, 121)]
+        let data: [(Double,Double)] = [(10, 30), (20, 61), (30, 85), (40, 121)]
         assertPerformanceComplexity(data, complexity: .linear)
     }
 
     // MARK: Quadratic
 
     func testQuadraticSlopeOne() {
-        let data: Benchmark = [(10, 100), (20, 400), (30, 900), (40, 1640)]
+        let data: [(Double,Double)] = [(10, 100), (20, 400), (30, 900), (40, 1640)]
         assertPerformanceComplexity(data, complexity: .quadratic)
     }
 
     func testQuadraticSlopeThree() {
-        let data: Benchmark = [(10, 300), (20, 1207), (30, 2704), (40, 4805)]
+        let data: [(Double,Double)] = [(10, 300), (20, 1207), (30, 2704), (40, 4805)]
         assertPerformanceComplexity(data, complexity: .quadratic)
     }
 
     // MARK: Cubic
 
     func testCubicSlopeOne() {
-        let data: Benchmark = [(10, 1000), (20, 4000), (30, 9000), (40, 16040)]
+        let data: [(Double,Double)] = [(10, 1000), (20, 4000), (30, 9000), (40, 16040)]
         assertPerformanceComplexity(data, complexity: .cubic)
     }
 
     func testCubicSlopeThree() {
-        let data: Benchmark = [(10, 3000), (20, 12007), (30, 27004), (40, 48050)]
+        let data: [(Double,Double)] = [(10, 3000), (20, 12007), (30, 27004), (40, 48050)]
         assertPerformanceComplexity(data, complexity: .cubic)
     }
 
     // MARK: Exponential
 
     func testExponentialBaseTwoSlopeOne() {
-        let data: Benchmark = [(10, 1024), (20, 1e6), (30, 1e9), (40, 1e12)]
+        let data: [(Double,Double)] = [(10, 1024), (20, 1e6), (30, 1e9), (40, 1e12)]
         assertPerformanceComplexity(data, complexity: .exponential)
     }
 
     func testExponentialBaseTwoSlopeThree() {
-        let data: Benchmark = [(10, 3072), (20, 3e6), (30, 3e9), (40, 3e12)]
+        let data: [(Double,Double)] = [(10, 3072), (20, 3e6), (30, 3e9), (40, 3e12)]
         assertPerformanceComplexity(data, complexity: .exponential)
     }
 }


### PR DESCRIPTION
This PR is a bit experimental, though it is the beginnings of a process to encapsulate some of the test information.

- `Benchmark` was expanded from a `typealias` to a `struct` containing `[Test]`
- `Test` was created to store each of the results for a single input size
- The more general-use algorithms (`linearRegression`) were given (back) more general-use terminology (`data` not `benchmark`)
- `testPoint` was renamed as `inputSize` where applicable

Part of this was done so that we could store some of this information for diagnostics after the fact (instead of using debugging during runtime).

Further work could be to store the names of the structures and operations in the `Benchmark` struct.