### PR TITLE
Rewrite PerformanceTestCase API

### DIFF
--- a/Sources/PerformanceTesting/ArrayExtensions.swift
+++ b/Sources/PerformanceTesting/ArrayExtensions.swift
@@ -1,0 +1,17 @@
+//
+// ArrayExtensions.swift
+// 2017-08-14
+// Author: Brian Heim
+//
+
+extension Array where Element == Double {
+
+    public var sum: Double {
+        return reduce(0,+)
+    }
+
+    public var average: Double {
+        assert(count > 0)
+        return sum / Double(count)
+    }
+}

--- a/Sources/PerformanceTesting/LinearRegression.swift
+++ b/Sources/PerformanceTesting/LinearRegression.swift
@@ -18,10 +18,10 @@ internal func linearRegression(_ data: Benchmark) -> Regression {
 
     let xs = data.map { $0.0 }
     let ys = data.map { $0.1 }
-    let sumOfXs = xs.reduce(0,+)
-    let sumOfYs = ys.reduce(0,+)
-    let sumOfXsSquared = xs.map { pow($0,2) }.reduce(0,+)
-    let sumOfXsTimesYs = data.map(*).reduce(0,+)
+    let sumOfXs = xs.sum
+    let sumOfYs = ys.sum
+    let sumOfXsSquared = xs.map { pow($0,2) }.sum
+    let sumOfXsTimesYs = data.map(*).sum
 
     let denominator = Double(data.count) * sumOfXsSquared - pow(sumOfXs, 2)
     let interceptNumerator = sumOfYs * sumOfXsSquared - sumOfXs * sumOfXsTimesYs
@@ -41,11 +41,11 @@ private func correlation(_ benchmark: Benchmark, sumOfXs: Double, sumOfYs: Doubl
     -> Double
 {
     let meanOfYs = sumOfYs / Double(benchmark.count)
-    let squaredErrorOfYs = benchmark.map { pow($0.1 - meanOfYs, 2) }.reduce(0,+)
+    let squaredErrorOfYs = benchmark.map { pow($0.1 - meanOfYs, 2) }.sum
     let denominator = squaredErrorOfYs
     guard denominator != 0 else { return 0 }
     let meanOfXs = sumOfXs / Double(benchmark.count)
-    let squaredErrorOfXs = benchmark.map { pow($0.0 - meanOfXs, 2) }.reduce(0,+)
+    let squaredErrorOfXs = benchmark.map { pow($0.0 - meanOfXs, 2) }.sum
     let numerator = squaredErrorOfXs
     return sqrt(numerator / denominator) * slope
 }

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -154,23 +154,6 @@ open class PerformanceTestCase: XCTestCase {
         let finishTime: Double = CFAbsoluteTimeGetCurrent()
         return finishTime - startTime
     }
-
-/* TODO: not sure if this is needed yet
-    public func time(
-        repetitions: Int,
-        _ closure: () -> Void
-    ) -> Double
-    {
-        assert(repetitions > 0)
-        let startTime: Double = CFAbsoluteTimeGetCurrent()
-        for _ in 0..<repetitions {
-            closure()
-        }
-        let finishTime: Double = CFAbsoluteTimeGetCurrent()
-        return finishTime - startTime
-    }
-*/
-
 }
 
 extension Array where Array == Benchmark {

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -124,9 +124,7 @@ open class PerformanceTestCase: XCTestCase {
         }
     }
 
-    public func measure(
-        _ closure: () -> Void
-    ) -> Double
+    public func measure(_ closure: () -> Void) -> Double
     {
         let measures: [Double] = (0..<10).map { _ in
             let startTime: Double = CFAbsoluteTimeGetCurrent()
@@ -137,17 +135,13 @@ open class PerformanceTestCase: XCTestCase {
         return measures.average
     }
 
-    public func measureMutable(
-        _ closure: () -> Double
-    ) -> Double
+    public func measureMutable(_ closure: () -> Double) -> Double
     {
         let measures: [Double] = (0..<10).map { _ in closure() }
         return measures.average
     }
 
-    public func time(
-        _ closure: () -> Void
-    ) -> Double
+    public func time(_ closure: () -> Void) -> Double
     {
         let startTime: Double = CFAbsoluteTimeGetCurrent()
         closure()

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -148,11 +148,11 @@ open class PerformanceTestCase: XCTestCase {
 
 }
 
-/// Maps data representing performance of a certain complexity so that it
-/// can be fit with linear regression. This is done by applying the inverse
-/// function of the expected performance function.
 extension Array where Array == Benchmark {
 
+    /// Maps data representing performance of a certain complexity so that it
+    /// can be fit with linear regression. This is done by applying the inverse
+    /// function of the expected performance function.
     public func mappedForLinearFit(complexity: Complexity) -> Array {
         return self.map { ($0, complexity.inverse($1)) }
     }

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -47,6 +47,9 @@ open class PerformanceTestCase: XCTestCase {
         }
 
         XCTAssertEqual(results.slope, 0, accuracy: accuracy)
+        XCTAssert(results.correlation < 0.9,
+            "Constant-time performance should not have a linearly correlated slope"
+        )
     }
 
     /// Assert that the data indicates that performance fits well to the given

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -8,6 +8,13 @@
 import Foundation
 import XCTest
 
+// for fflush(stdout)
+#if os(Linux)
+    import Glibc
+#else
+    import Darwin.C
+#endif
+
 open class PerformanceTestCase: XCTestCase {
 
     // MARK: Nested Types
@@ -27,7 +34,24 @@ open class PerformanceTestCase: XCTestCase {
     ) -> Benchmark
     {
         let testPoints = Scale.medium
-        let benchmarkResults = testPoints.map { operation($0) }
+        let benchmarkResults = testPoints.map { testPoint -> Double in
+            var result = 3.0
+            if Configuration.verbose {
+                // So we know exactly where we're hanging. Swift seems to only
+                // flush at newlines, so manually flush here
+                print("\(#function): (\(testPoint), ", terminator:"")
+                fflush(stdout)
+            }
+
+            result = operation(testPoint)
+
+            if Configuration.verbose {
+                print("\(result))")
+            }
+
+            return result
+        }
+
         let doubleTestPoints: [Double] = testPoints.map(Double.init)
         return Array(zip(doubleTestPoints, benchmarkResults))
     }

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -120,17 +120,11 @@ open class PerformanceTestCase: XCTestCase {
         }
     }
 
-    public func measure(_ closure: () -> Void) -> Double {
-        let measures: [Double] = (0..<10).map { _ in
-            let startTime: Double = CFAbsoluteTimeGetCurrent()
-            closure()
-            let finishTime: Double = CFAbsoluteTimeGetCurrent()
-            return finishTime - startTime
-        }
-        return measures.average
+    public func meanExecutionTime(_ closure: () -> Void) -> Double {
+        return meanOutcome { time(closure) }
     }
 
-    public func measureMutable(_ closure: () -> Double) -> Double {
+    public func meanOutcome(_ closure: () -> Double) -> Double {
         return (0..<10).map { _ in closure() }.average
     }
 

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -110,7 +110,7 @@ open class PerformanceTestCase: XCTestCase {
         XCTAssert(results.correlation >= minimumCorrelation)
     }
 
-    public func assertPerformance(_ complexity: Complexity, _ operation: (Int) -> Double) {
+    public func assertPerformance(_ complexity: Complexity, of operation: (Int) -> Double) {
         let data = benchmark(operation)
         switch complexity {
         case .constant:

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -142,9 +142,9 @@ open class PerformanceTestCase: XCTestCase {
 
     public func time(_ closure: () -> Void) -> Double
     {
-        let startTime: Double = CFAbsoluteTimeGetCurrent()
+        let startTime = CFAbsoluteTimeGetCurrent()
         closure()
-        let finishTime: Double = CFAbsoluteTimeGetCurrent()
+        let finishTime = CFAbsoluteTimeGetCurrent()
         return finishTime - startTime
     }
 }

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -23,12 +23,13 @@ open class PerformanceTestCase: XCTestCase {
 
     /// Benchmarks the performance of a closure.
     public func benchmark(
-        _ operation: (Double) -> Double
+        _ operation: (Int) -> Double
     ) -> Benchmark
     {
         let testPoints = Scale.medium
-        let results = testPoints.map { operation($0) }
-        return Array(zip(testPoints, results))
+        let benchmarkResults = testPoints.map { operation($0) }
+        let doubleTestPoints: [Double] = testPoints.map(Double.init)
+        return Array(zip(doubleTestPoints, benchmarkResults))
     }
 
     /// Assert that the data indicates that performance is constant-time ( O(1) ).
@@ -87,7 +88,7 @@ open class PerformanceTestCase: XCTestCase {
 
     public func assertPerformance(
         _ complexity: Complexity,
-        _ operation: (Double) -> Double
+        _ operation: (Int) -> Double
     )
     {
         let data = benchmark(operation)

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -22,7 +22,7 @@ open class PerformanceTestCase: XCTestCase {
     // MARK: Instance Methods
 
     /// Benchmarks the performance of a closure.
-    public func benchmark (
+    public func benchmark(
         _ operation: (Double) -> Double
     ) -> Benchmark
     {

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -137,8 +137,7 @@ open class PerformanceTestCase: XCTestCase {
 
     public func measureMutable(_ closure: () -> Double) -> Double
     {
-        let measures: [Double] = (0..<10).map { _ in closure() }
-        return measures.average
+        return (0..<10).map { _ in closure() }.average
     }
 
     public func time(_ closure: () -> Void) -> Double

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -110,11 +110,7 @@ open class PerformanceTestCase: XCTestCase {
         XCTAssert(results.correlation >= minimumCorrelation)
     }
 
-    public func assertPerformance(
-        _ complexity: Complexity,
-        _ operation: (Int) -> Double
-    )
-    {
+    public func assertPerformance(_ complexity: Complexity, _ operation: (Int) -> Double) {
         let data = benchmark(operation)
         switch complexity {
         case .constant:
@@ -124,8 +120,7 @@ open class PerformanceTestCase: XCTestCase {
         }
     }
 
-    public func measure(_ closure: () -> Void) -> Double
-    {
+    public func measure(_ closure: () -> Void) -> Double {
         let measures: [Double] = (0..<10).map { _ in
             let startTime: Double = CFAbsoluteTimeGetCurrent()
             closure()
@@ -135,13 +130,11 @@ open class PerformanceTestCase: XCTestCase {
         return measures.average
     }
 
-    public func measureMutable(_ closure: () -> Double) -> Double
-    {
+    public func measureMutable(_ closure: () -> Double) -> Double {
         return (0..<10).map { _ in closure() }.average
     }
 
-    public func time(_ closure: () -> Void) -> Double
-    {
+    public func time(_ closure: () -> Void) -> Double {
         let startTime = CFAbsoluteTimeGetCurrent()
         closure()
         let finishTime = CFAbsoluteTimeGetCurrent()

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -10,11 +10,6 @@ import XCTest
 
 open class PerformanceTestCase: XCTestCase {
 
-    // MARK: Associated Types
-
-    public typealias Setup <Structure> = (inout Structure, Double) -> Void
-    public typealias Operation = (Double) -> Double
-
     // MARK: Nested Types
 
     // FIXME: Consider making this `DebugLevel`
@@ -28,7 +23,7 @@ open class PerformanceTestCase: XCTestCase {
 
     /// Benchmarks the performance of a closure.
     public func benchmark (
-        _ operation: Operation
+        _ operation: (Double) -> Double
     ) -> Benchmark
     {
         let testPoints = Scale.medium

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -158,14 +158,3 @@ extension Array where Array == Benchmark {
     }
 }
 
-extension Array where Element == Double {
-
-    public var sum: Double {
-        return reduce(0,+)
-    }
-
-    public var average: Double {
-        assert(count > 0)
-        return sum / Double(count)
-    }
-}

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -85,6 +85,20 @@ open class PerformanceTestCase: XCTestCase {
         XCTAssert(results.correlation >= minimumCorrelation)
     }
 
+    public func assertPerformance(
+        _ complexity: Complexity,
+        _ operation: (Double) -> Double
+    )
+    {
+        let data = benchmark(operation)
+        switch complexity {
+        case .constant:
+            assertConstantTimePerformance(data)
+        default:
+            assertPerformanceComplexity(data, complexity: complexity)
+        }
+    }
+
     public func measure(
         _ closure: () -> Void
     ) -> Double
@@ -97,6 +111,41 @@ open class PerformanceTestCase: XCTestCase {
         }
         return measures.average
     }
+
+    public func measureMutable(
+        _ closure: () -> Double
+    ) -> Double
+    {
+        let measures: [Double] = (0..<10).map { _ in closure() }
+        return measures.average
+    }
+
+    public func time(
+        _ closure: () -> Void
+    ) -> Double
+    {
+        let startTime: Double = CFAbsoluteTimeGetCurrent()
+        closure()
+        let finishTime: Double = CFAbsoluteTimeGetCurrent()
+        return finishTime - startTime
+    }
+
+/* TODO: not sure if this is needed yet
+    public func time(
+        repetitions: Int,
+        _ closure: () -> Void
+    ) -> Double
+    {
+        assert(repetitions > 0)
+        let startTime: Double = CFAbsoluteTimeGetCurrent()
+        for _ in 0..<repetitions {
+            closure()
+        }
+        let finishTime: Double = CFAbsoluteTimeGetCurrent()
+        return finishTime - startTime
+    }
+*/
+
 }
 
 /// Maps data representing performance of a certain complexity so that it

--- a/Sources/PerformanceTesting/Scale.swift
+++ b/Sources/PerformanceTesting/Scale.swift
@@ -15,8 +15,12 @@ public struct Scale {
     public static let large  = exponentialSeries(size: 10, from: 1000, to: 1_000_000_000)
 }
 
-// Creates an array of Doubles in an exponential series.
-private func exponentialSeries(size: Int, from start: Double, to end: Double) -> [Double] {
-    let base = pow(end - start + 1, 1 / (Double(size)-1))
-    return (0..<size).map { pow(base, Double($0)) + start - 1 }.map(round)
+// Creates an array of rounded Ints in an approximate exponential series.
+private func exponentialSeries(size: Int, from start: Int, to end: Int) -> [Int] {
+    let range = Double(end - start + 1)
+    let base = pow(range, 1 / (Double(size)-1))
+    let floatingPointSeries = (0..<size).map { pow(base, Double($0)) + Double(start) - 1 }
+
+    // round first to avoid truncation
+    return floatingPointSeries.map { Int(round($0)) }
 }

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -13,7 +13,7 @@ class ArrayTests: PerformanceTestCase {
     // MARK: Helper functions.
 
     // Constructs an array of size `n` with linearly increasing elements.
-    func constructArray(size n: Int) -> [Int] {
+    func makeArray(size n: Int) -> [Int] {
         var array: [Int] = []
         array.reserveCapacity(n)
         for i in 0..<n {
@@ -23,7 +23,7 @@ class ArrayTests: PerformanceTestCase {
     }
 
     // Constructs an array of size `n` with random elements.
-    func constructRandomArray(size n: Int) -> [Int] {
+    func makeRandomArray(size n: Int) -> [Int] {
         var array: [Int] = []
         array.reserveCapacity(n)
         for _ in 0..<n {
@@ -38,7 +38,7 @@ class ArrayTests: PerformanceTestCase {
     // `isEmpty` should be constant-time in the number of elements
     func testIsEmpty() {
         assertPerformance(.constant) { testPoint in
-            let array = constructArray(size: testPoint)
+            let array = makeArray(size: testPoint)
             return measure { _ = array.isEmpty }
         }
     }
@@ -46,7 +46,7 @@ class ArrayTests: PerformanceTestCase {
     // `count` should be constant-time in the number of elements
     func testCount() {
         assertPerformance(.constant) { testPoint in
-            let array = constructArray(size: testPoint)
+            let array = makeArray(size: testPoint)
             return measure { _ = array.count }
         }
     }
@@ -56,7 +56,7 @@ class ArrayTests: PerformanceTestCase {
     // `subscript` should be constant-time in the number of elements
     func testSubscript() {
         assertPerformance(.constant) { testPoint in
-            let array = constructArray(size: testPoint)
+            let array = makeArray(size: testPoint)
             return measure { _ = array[3] }
         }
     }
@@ -64,7 +64,7 @@ class ArrayTests: PerformanceTestCase {
     // `first` should be constant-time in the number of elements
     func testFirst() {
         assertPerformance(.constant) { testPoint in
-            let array = constructArray(size: testPoint)
+            let array = makeArray(size: testPoint)
             return measure { _ = array.first }
         }
     }
@@ -72,7 +72,7 @@ class ArrayTests: PerformanceTestCase {
     // `last` should be constant-time in the number of elements
     func testLast() {
         assertPerformance(.constant) { testPoint in
-            let array = constructArray(size: testPoint)
+            let array = makeArray(size: testPoint)
             return measure { _ = array.last }
         }
     }
@@ -83,7 +83,7 @@ class ArrayTests: PerformanceTestCase {
     func testAppend() {
         assertPerformance(.constant) { testPoint in
             return measureMutable {
-                var array = constructArray(size: testPoint)
+                var array = makeArray(size: testPoint)
                 return time { array.append(6) }
             }
         }
@@ -105,7 +105,7 @@ class ArrayTests: PerformanceTestCase {
     func testInsert() {
         assertPerformance(.linear) { testPoint in
             return measureMutable {
-                var array = constructArray(size: testPoint)
+                var array = makeArray(size: testPoint)
                 return time { array.insert(6, at: 0) }
             }
         }
@@ -118,7 +118,7 @@ class ArrayTests: PerformanceTestCase {
     func testRemove() {
         assertPerformance(.linear) { testPoint in
             return measureMutable {
-                var array = constructRandomArray(size: testPoint)
+                var array = makeRandomArray(size: testPoint)
                 return time { array.remove(at: 0) }
             }
         }
@@ -132,7 +132,7 @@ class ArrayTests: PerformanceTestCase {
     func testSort() {
         assertPerformance(.linear) { testPoint in
             return measureMutable {
-                var array = constructRandomArray(size: testPoint)
+                var array = makeRandomArray(size: testPoint)
                 return time { array.sort() }
             }
         }
@@ -142,7 +142,7 @@ class ArrayTests: PerformanceTestCase {
     func testPartition() {
         assertPerformance(.linear) { testPoint in
             return measureMutable {
-                var array = constructRandomArray(size: testPoint)
+                var array = makeRandomArray(size: testPoint)
                 return time {
                     _ = array.partition { element in element > 50 }
                 }

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -39,7 +39,7 @@ class ArrayTests: PerformanceTestCase {
     func testIsEmpty() {
         assertPerformance(.constant) { testPoint in
             let array = makeArray(size: testPoint)
-            return measure { _ = array.isEmpty }
+            return meanExecutionTime { _ = array.isEmpty }
         }
     }
 
@@ -47,7 +47,7 @@ class ArrayTests: PerformanceTestCase {
     func testCount() {
         assertPerformance(.constant) { testPoint in
             let array = makeArray(size: testPoint)
-            return measure { _ = array.count }
+            return meanExecutionTime { _ = array.count }
         }
     }
 
@@ -57,7 +57,7 @@ class ArrayTests: PerformanceTestCase {
     func testSubscript() {
         assertPerformance(.constant) { testPoint in
             let array = makeArray(size: testPoint)
-            return measure { _ = array[3] }
+            return meanExecutionTime { _ = array[3] }
         }
     }
 
@@ -65,7 +65,7 @@ class ArrayTests: PerformanceTestCase {
     func testFirst() {
         assertPerformance(.constant) { testPoint in
             let array = makeArray(size: testPoint)
-            return measure { _ = array.first }
+            return meanExecutionTime { _ = array.first }
         }
     }
 
@@ -73,7 +73,7 @@ class ArrayTests: PerformanceTestCase {
     func testLast() {
         assertPerformance(.constant) { testPoint in
             let array = makeArray(size: testPoint)
-            return measure { _ = array.last }
+            return meanExecutionTime { _ = array.last }
         }
     }
 
@@ -82,7 +82,7 @@ class ArrayTests: PerformanceTestCase {
     // `append` should be (amortized) constant-time in the number of elements
     func testAppend() {
         assertPerformance(.constant) { testPoint in
-            return measureMutable {
+            return meanOutcome {
                 var array = makeArray(size: testPoint)
                 return time { array.append(6) }
             }
@@ -92,7 +92,7 @@ class ArrayTests: PerformanceTestCase {
     // `append` should be (amortized) linear-time in the number of appends
     func testAppendAmortized() {
         assertPerformance(.linear) { testPoint in
-            return measureMutable {
+            return meanOutcome {
                 var array: [Int] = []
                 return time {
                     for _ in 0..<testPoint { array.append(6) }
@@ -104,7 +104,7 @@ class ArrayTests: PerformanceTestCase {
     // `insert` should be O(n) in the number of elements
     func testInsert() {
         assertPerformance(.linear) { testPoint in
-            return measureMutable {
+            return meanOutcome {
                 var array = makeArray(size: testPoint)
                 return time { array.insert(6, at: 0) }
             }
@@ -117,7 +117,7 @@ class ArrayTests: PerformanceTestCase {
     // `remove` should be constant-time in the number of elements
     func testRemove() {
         assertPerformance(.linear) { testPoint in
-            return measureMutable {
+            return meanOutcome {
                 var array = makeRandomArray(size: testPoint)
                 return time { array.remove(at: 0) }
             }
@@ -131,7 +131,7 @@ class ArrayTests: PerformanceTestCase {
     // a line to it well enough.
     func testSort() {
         assertPerformance(.linear) { testPoint in
-            return measureMutable {
+            return meanOutcome {
                 var array = makeRandomArray(size: testPoint)
                 return time { array.sort() }
             }
@@ -141,7 +141,7 @@ class ArrayTests: PerformanceTestCase {
     // `partition` should be O(n) in the number of elements
     func testPartition() {
         assertPerformance(.linear) { testPoint in
-            return measureMutable {
+            return meanOutcome {
                 var array = makeRandomArray(size: testPoint)
                 return time {
                     _ = array.partition { element in element > 50 }

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -13,7 +13,7 @@ class ArrayTests: PerformanceTestCase {
     // MARK: Helper functions.
 
     // Constructs an array of size `n` with linearly increasing elements.
-    func constructSizeNArray(size n: Int) -> [Int] {
+    func constructArray(size n: Int) -> [Int] {
         var array: [Int] = []
         array.reserveCapacity(Int(n))
         for i in 0..<Int(n) {
@@ -23,7 +23,7 @@ class ArrayTests: PerformanceTestCase {
     }
 
     // Constructs an array of size `n` with random elements.
-    func constructRandomSizeNArray(size n: Int) -> [Int] {
+    func constructRandomArray(size n: Int) -> [Int] {
         var array: [Int] = []
         array.reserveCapacity(Int(n))
         for _ in 0..<Int(n) {
@@ -38,22 +38,22 @@ class ArrayTests: PerformanceTestCase {
     // `isEmpty` should be constant-time in the number of elements
     func testIsEmpty() {
         let data = benchmark { testPoint in
-            let array = constructSizeNArray(size: Int(testPoint))
+            let array = constructArray(size: Int(testPoint))
             return measure { _ = array.isEmpty }
         }
         assertConstantTimePerformance(data)
     }
-/*
+
     // `count` should be constant-time in the number of elements
     func testCount() {
-        let data = benchmark(
-            structure: [],
-            setup: constructSizeNArray,
-            measuring: { array, _ in _ = array.count }
+        let data = benchmark { testPoint in
+            let array = constructArray(size: Int(testPoint))
+            return measure { _ = array.count }
         )
         assertConstantTimePerformance(data)
     }
 
+/*
     // MARK: Tests: accessing elements
 
     // `subscript` should be constant-time in the number of elements

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -61,54 +61,55 @@ class ArrayTests: PerformanceTestCase {
         }
     }
 
-/*
     // `first` should be constant-time in the number of elements
     func testFirst() {
-        let data = benchmark(
-            structure: [],
-            setup: constructSizeNArray,
-            measuring: { array, _ in _ = array.first }
-        )
-        assertConstantTimePerformance(data)
+        assertPerformance(.constant) { testPoint in
+            let array = constructArray(size: Int(testPoint))
+            return measure { _ = array.first }
+        }
     }
 
     // `last` should be constant-time in the number of elements
     func testLast() {
-        let data = benchmark(
-            structure: [],
-            setup: constructSizeNArray,
-            measuring: { array, _ in _ = array.last }
-        )
-        assertConstantTimePerformance(data)
+        assertPerformance(.constant) { testPoint in
+            let array = constructArray(size: Int(testPoint))
+            return measure { _ = array.last }
+        }
     }
 
     // MARK: Tests: adding elements
 
     // `append` should be (amortized) constant-time in the number of elements
     func testAppend() {
-        let data = benchmark(
-            structure: [],
-            setup: constructSizeNArray,
-            measuring: { array, _ in array.append(6) }
-        )
-        assertConstantTimePerformance(data)
+        assertPerformance(.constant) { testPoint in
+            return measureMutable {
+                var array = constructArray(size: Int(testPoint))
+                return time { array.append(6) }
+            }
+        }
+    }
+
+    // `append` should be (amortized) linear-time in the number of appends
+    func testAppendAmortized() {
+        assertPerformance(.linear) { testPoint in
+            return measureMutable {
+                var array: [Int] = []
+                return time {
+                    for _ in 0..<Int(testPoint) { array.append(6) }
+                }
+            }
+        }
     }
 
     // `insert` should be O(n) in the number of elements
     func testInsert() {
-        let data = benchmark(
-            structure: [],
-            setup: constructSizeNArray,
-            measuring: { array, _ in
-                for _ in 0..<100 {
-                    array.insert(6, at: 0)
-                }
+        assertPerformance(.linear) { testPoint in
+            return measureMutable {
+                var array = constructArray(size: Int(testPoint))
+                return time { array.insert(6, at: 0) }
             }
-        )
-        assertPerformanceComplexity(data, complexity: .linear)
+        }
     }
-
-*/
 
     // MARK: Tests: removing elements
 

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -27,8 +27,7 @@ class ArrayTests: PerformanceTestCase {
         var array: [Int] = []
         array.reserveCapacity(n)
         for _ in 0..<n {
-            let randomNumber = Int(arc4random_uniform(UInt32(n)))
-            array.append(randomNumber)
+            array.append(n.random())
         }
         return array
     }

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -38,7 +38,7 @@ class ArrayTests: PerformanceTestCase {
     // `isEmpty` should be constant-time in the number of elements
     func testIsEmpty() {
         assertPerformance(.constant) { testPoint in
-            let array = constructArray(size: Int(testPoint))
+            let array = constructArray(size: testPoint)
             return measure { _ = array.isEmpty }
         }
     }
@@ -46,7 +46,7 @@ class ArrayTests: PerformanceTestCase {
     // `count` should be constant-time in the number of elements
     func testCount() {
         assertPerformance(.constant) { testPoint in
-            let array = constructArray(size: Int(testPoint))
+            let array = constructArray(size: testPoint)
             return measure { _ = array.count }
         }
     }
@@ -56,7 +56,7 @@ class ArrayTests: PerformanceTestCase {
     // `subscript` should be constant-time in the number of elements
     func testSubscript() {
         assertPerformance(.constant) { testPoint in
-            let array = constructArray(size: Int(testPoint))
+            let array = constructArray(size: testPoint)
             return measure { _ = array[3] }
         }
     }
@@ -64,7 +64,7 @@ class ArrayTests: PerformanceTestCase {
     // `first` should be constant-time in the number of elements
     func testFirst() {
         assertPerformance(.constant) { testPoint in
-            let array = constructArray(size: Int(testPoint))
+            let array = constructArray(size: testPoint)
             return measure { _ = array.first }
         }
     }
@@ -72,7 +72,7 @@ class ArrayTests: PerformanceTestCase {
     // `last` should be constant-time in the number of elements
     func testLast() {
         assertPerformance(.constant) { testPoint in
-            let array = constructArray(size: Int(testPoint))
+            let array = constructArray(size: testPoint)
             return measure { _ = array.last }
         }
     }
@@ -83,7 +83,7 @@ class ArrayTests: PerformanceTestCase {
     func testAppend() {
         assertPerformance(.constant) { testPoint in
             return measureMutable {
-                var array = constructArray(size: Int(testPoint))
+                var array = constructArray(size: testPoint)
                 return time { array.append(6) }
             }
         }
@@ -95,7 +95,7 @@ class ArrayTests: PerformanceTestCase {
             return measureMutable {
                 var array: [Int] = []
                 return time {
-                    for _ in 0..<Int(testPoint) { array.append(6) }
+                    for _ in 0..<testPoint { array.append(6) }
                 }
             }
         }
@@ -105,7 +105,7 @@ class ArrayTests: PerformanceTestCase {
     func testInsert() {
         assertPerformance(.linear) { testPoint in
             return measureMutable {
-                var array = constructArray(size: Int(testPoint))
+                var array = constructArray(size: testPoint)
                 return time { array.insert(6, at: 0) }
             }
         }
@@ -118,7 +118,7 @@ class ArrayTests: PerformanceTestCase {
     func testRemove() {
         assertPerformance(.linear) { testPoint in
             return measureMutable {
-                var array = constructRandomArray(size: Int(testPoint))
+                var array = constructRandomArray(size: testPoint)
                 return time { array.remove(at: 0) }
             }
         }
@@ -132,7 +132,7 @@ class ArrayTests: PerformanceTestCase {
     func testSort() {
         assertPerformance(.linear) { testPoint in
             return measureMutable {
-                var array = constructRandomArray(size: Int(testPoint))
+                var array = constructRandomArray(size: testPoint)
                 return time { array.sort() }
             }
         }
@@ -142,7 +142,7 @@ class ArrayTests: PerformanceTestCase {
     func testPartition() {
         assertPerformance(.linear) { testPoint in
             return measureMutable {
-                var array = constructRandomArray(size: Int(testPoint))
+                var array = constructRandomArray(size: testPoint)
                 return time {
                     _ = array.partition { element in element > 50 }
                 }

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -49,7 +49,7 @@ class ArrayTests: PerformanceTestCase {
         let data = benchmark { testPoint in
             let array = constructArray(size: Int(testPoint))
             return measure { _ = array.count }
-        )
+        }
         assertConstantTimePerformance(data)
     }
 

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -37,35 +37,31 @@ class ArrayTests: PerformanceTestCase {
 
     // `isEmpty` should be constant-time in the number of elements
     func testIsEmpty() {
-        let data = benchmark { testPoint in
+        assertPerformance(.constant) { testPoint in
             let array = constructArray(size: Int(testPoint))
             return measure { _ = array.isEmpty }
         }
-        assertConstantTimePerformance(data)
     }
 
     // `count` should be constant-time in the number of elements
     func testCount() {
-        let data = benchmark { testPoint in
+        assertPerformance(.constant) { testPoint in
             let array = constructArray(size: Int(testPoint))
             return measure { _ = array.count }
         }
-        assertConstantTimePerformance(data)
     }
 
-/*
     // MARK: Tests: accessing elements
 
     // `subscript` should be constant-time in the number of elements
     func testSubscript() {
-        let data = benchmark(
-            structure: [],
-            setup: constructSizeNArray,
-            measuring: { array, _ in _ = array[3] }
-        )
-        assertConstantTimePerformance(data)
+        assertPerformance(.constant) { testPoint in
+            let array = constructArray(size: Int(testPoint))
+            return measure { _ = array[3] }
+        }
     }
 
+/*
     // `first` should be constant-time in the number of elements
     func testFirst() {
         let data = benchmark(
@@ -112,20 +108,19 @@ class ArrayTests: PerformanceTestCase {
         assertPerformanceComplexity(data, complexity: .linear)
     }
 
+*/
+
     // MARK: Tests: removing elements
 
-    // `remove` should be O(n) in the number of elements
+
+    // `remove` should be constant-time in the number of elements
     func testRemove() {
-        let data = benchmark(
-            structure: [],
-            setup: constructSizeNArray,
-            measuring: { array, n in
-                for _ in 0..<100 {
-                    _ = array.remove(at: 0)
-                }
+        assertPerformance(.linear) { testPoint in
+            return measureMutable {
+                var array = constructRandomArray(size: Int(testPoint))
+                return time { array.remove(at: 0) }
             }
-        )
-        assertPerformanceComplexity(data, complexity: .linear)
+        }
     }
 
     // MARK: Tests: sorting an array
@@ -134,26 +129,23 @@ class ArrayTests: PerformanceTestCase {
     // Technically, it's linearithmic, but we should be able to fit
     // a line to it well enough.
     func testSort() {
-        let data = benchmark(
-            structure: [],
-            setup: constructRandomSizeNArray,
-            measuring: { array, n in
-                array.sort()
+        assertPerformance(.linear) { testPoint in
+            return measureMutable {
+                var array = constructRandomArray(size: Int(testPoint))
+                return time { array.sort() }
             }
-        )
-        assertPerformanceComplexity(data, complexity: .linear)
+        }
     }
 
     // `partition` should be O(n) in the number of elements
     func testPartition() {
-        let data = benchmark(
-            structure: [],
-            setup: constructRandomSizeNArray,
-            measuring: { array, n in
-                _ = array.partition { element in element > 50 }
+        assertPerformance(.linear) { testPoint in
+            return measureMutable {
+                var array = constructRandomArray(size: Int(testPoint))
+                return time {
+                    _ = array.partition { element in element > 50 }
+                }
             }
-        )
-        assertPerformanceComplexity(data, complexity: .linear)
+        }
     }
-*/
 }

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -15,8 +15,8 @@ class ArrayTests: PerformanceTestCase {
     // Constructs an array of size `n` with linearly increasing elements.
     func constructArray(size n: Int) -> [Int] {
         var array: [Int] = []
-        array.reserveCapacity(Int(n))
-        for i in 0..<Int(n) {
+        array.reserveCapacity(n)
+        for i in 0..<n {
             array.append(i)
         }
         return array
@@ -25,8 +25,8 @@ class ArrayTests: PerformanceTestCase {
     // Constructs an array of size `n` with random elements.
     func constructRandomArray(size n: Int) -> [Int] {
         var array: [Int] = []
-        array.reserveCapacity(Int(n))
-        for _ in 0..<Int(n) {
+        array.reserveCapacity(n)
+        for _ in 0..<n {
             let randomNumber = Int(arc4random_uniform(UInt32(n)))
             array.append(randomNumber)
         }

--- a/Tests/PerformanceTestingTests/IntExtensions.swift
+++ b/Tests/PerformanceTestingTests/IntExtensions.swift
@@ -1,0 +1,17 @@
+//
+//  IntExtensions.swift
+//  PerformanceTestingTests
+//
+//  Created by Brian Heim on 8/21/17
+//
+
+import Foundation
+
+extension Int {
+
+    /// - Returns: a uniform random number in the range [0, self)
+    public func random() -> Int {
+        assert(self >= 0)
+        return Int(arc4random_uniform(UInt32(self)))
+    }
+}

--- a/Tests/PerformanceTestingTests/SetTests.swift
+++ b/Tests/PerformanceTestingTests/SetTests.swift
@@ -9,13 +9,14 @@ import XCTest
 import PerformanceTesting
 
 class SetTests: PerformanceTestCase {
-/*
+
     // MARK: Helper functions.
 
     // Constructs a set of size `n` with linearly increasing elements.
-    let constructSizeNSet: Setup<Set<Int>> = { set, n in
-        set.reserveCapacity(Int(n))
-        for i in 0..<Int(n) {
+    let constructSet(size n: Int) -> [Int] {
+        var set: [Int] = []
+        set.reserveCapacity(n)
+        for i in 0..<n {
             set.insert(i)
         }
     }
@@ -24,36 +25,39 @@ class SetTests: PerformanceTestCase {
 
     // `isEmpty` should be constant-time in the number of elements
     func testIsEmpty() {
-        let data = benchmark(
-            structure: Set.init(),
-            setup: constructSizeNSet,
-            measuring: { set, _ in _ = set.isEmpty }
-        )
-        assertConstantTimePerformance(data)
+        assertPerformance(.constant) { testPoint in
+            let set = constructSet(size: testPoint)
+            return measure { _ = array.isEmpty }
+        }
     }
 
     // `count` should be constant-time in the number of elements
     func testCount() {
-        let data = benchmark(
-            structure: Set.init(),
-            setup: constructSizeNSet,
-            measuring: { set, _ in _ = set.count }
-        )
-        assertConstantTimePerformance(data)
+        assertPerformance(.constant) { testPoint in
+            let set = constructSet(size: testPoint)
+            return measure { _ = array.count }
+        }
     }
 
     // `first` should be constant-time in the number of elements
     func testFirst() {
-        let data = benchmark(
-            structure: Set.init(),
-            setup: constructSizeNSet,
-            measuring: { set, _ in _ = set.first }
-        )
-        assertConstantTimePerformance(data)
+        assertPerformance(.constant) { testPoint in
+            let set = constructSet(size: testPoint)
+            return measure { _ = array.first }
+        }
+    }
+
+    // `last` should be constant-time in the number of elements
+    func testFirst() {
+        assertPerformance(.constant) { testPoint in
+            let set = constructSet(size: testPoint)
+            return measure { _ = array.last }
+        }
     }
 
     // MARK: Tests: membership
 
+/*
     // `contains` should be constant-time in the number of elements
     func testContains() {
         let data = benchmark(

--- a/Tests/PerformanceTestingTests/SetTests.swift
+++ b/Tests/PerformanceTestingTests/SetTests.swift
@@ -13,7 +13,7 @@ class SetTests: PerformanceTestCase {
     // MARK: Helper functions.
 
     // Constructs a set of size `n` with linearly increasing elements.
-    func constructSet(size n: Int) -> Set<Int> {
+    func makeSet(size n: Int) -> Set<Int> {
         var set = Set<Int>()
         set.reserveCapacity(n)
         for i in 0..<n {
@@ -32,7 +32,7 @@ class SetTests: PerformanceTestCase {
     // `isEmpty` should be constant-time in the number of elements
     func testIsEmpty() {
         assertPerformance(.constant) { testPoint in
-            let set = constructSet(size: testPoint)
+            let set = makeSet(size: testPoint)
             return measure { _ = set.isEmpty }
         }
     }
@@ -40,7 +40,7 @@ class SetTests: PerformanceTestCase {
     // `count` should be constant-time in the number of elements
     func testCount() {
         assertPerformance(.constant) { testPoint in
-            let set = constructSet(size: testPoint)
+            let set = makeSet(size: testPoint)
             return measure { _ = set.count }
         }
     }
@@ -48,7 +48,7 @@ class SetTests: PerformanceTestCase {
     // `first` should be constant-time in the number of elements
     func testFirst() {
         assertPerformance(.constant) { testPoint in
-            let set = constructSet(size: testPoint)
+            let set = makeSet(size: testPoint)
             return measure { _ = set.first }
         }
     }
@@ -58,7 +58,7 @@ class SetTests: PerformanceTestCase {
     // `contains` should be constant-time in the number of elements
     func testContains() {
         assertPerformance(.constant) { testPoint in
-            let set = constructSet(size: testPoint)
+            let set = makeSet(size: testPoint)
             return measure { _ = set.contains(randomInteger(testPoint*2)) }
         }
     }
@@ -69,7 +69,7 @@ class SetTests: PerformanceTestCase {
     func testInsert() {
         assertPerformance(.constant) { testPoint in
             return measureMutable {
-                var set = constructSet(size: testPoint)
+                var set = makeSet(size: testPoint)
                 return time {
                     // ensure an accurate reading, too noisy with just one iteration
                     for _ in 0..<100 {
@@ -85,7 +85,7 @@ class SetTests: PerformanceTestCase {
     // `filter` should be linear in the number of elements
     func testFilter() {
         assertPerformance(.linear) { testPoint in
-            let set = constructSet(size: testPoint)
+            let set = makeSet(size: testPoint)
             return measure {
                 _ = set.filter { $0 % 5 == 3 }
             }
@@ -96,7 +96,7 @@ class SetTests: PerformanceTestCase {
     func testRemove() {
         assertPerformance(.constant) { testPoint in
             return measureMutable {
-                var set = constructSet(size: testPoint)
+                var set = makeSet(size: testPoint)
                 return time { set.remove(randomInteger(testPoint*2)) }
             }
         }
@@ -106,7 +106,7 @@ class SetTests: PerformanceTestCase {
     func testRemoveFirst() {
         assertPerformance(.constant) { testPoint in
             return measureMutable {
-                var set = constructSet(size: testPoint)
+                var set = makeSet(size: testPoint)
                 return time { set.removeFirst() }
             }
         }
@@ -119,7 +119,7 @@ class SetTests: PerformanceTestCase {
     func testUnionWithConstantSizedOther() {
         assertPerformance(.constant) { testPoint in
             return measureMutable {
-                let benchSet = constructSet(size: testPoint)
+                let benchSet = makeSet(size: testPoint)
                 let otherSet = Set.init(0..<100)
                 return time { _ = benchSet.union(otherSet) }
             }
@@ -131,7 +131,7 @@ class SetTests: PerformanceTestCase {
     func testUnionWithLinearSizedOther() {
         assertPerformance(.linear) { testPoint in
             return measureMutable {
-                let benchSet = constructSet(size: testPoint)
+                let benchSet = makeSet(size: testPoint)
                 let otherSet = Set.init(0..<100)
                 return time { _ = otherSet.union(benchSet) }
             }

--- a/Tests/PerformanceTestingTests/SetTests.swift
+++ b/Tests/PerformanceTestingTests/SetTests.swift
@@ -102,31 +102,40 @@ class SetTests: PerformanceTestCase {
         }
     }
 
-    /*
     // `removeFirst` should be constant-time in the number of elements
     func testRemoveFirst() {
-        let data = benchmark(
-            structure: Set.init(),
-            setup: constructSizeNSet,
-            measuring: { set, n in
-                _ = set.removeFirst()
+        assertPerformance(.constant) { testPoint in
+            return measureMutable {
+                var set = constructSet(size: testPoint)
+                return time { set.removeFirst() }
             }
-        )
-        assertConstantTimePerformance(data)
+        }
     }
 
     // MARK: Tests: combining sets
 
     // `union` should be linear in the number of elements inserted
-    func testUnion() {
-        let data = benchmark(
-            structure: Set.init(),
-            setup: constructSizeNSet,
-            measuring: { set, n in
-                _ = set.union(Set.init(0..<300))
+    // Since we are inserting a constant-size set, this is constant time.
+    func testUnionWithConstantSizedOther() {
+        assertPerformance(.constant) { testPoint in
+            return measureMutable {
+                let benchSet = constructSet(size: testPoint)
+                let otherSet = Set.init(0..<100)
+                return time { _ = benchSet.union(otherSet) }
             }
-        )
-        assertConstantTimePerformance(data)
+        }
     }
-*/
+
+    // `union` should be linear in the number of elements inserted
+    // Since we are inserting a size-n set, this is linear time.
+    func testUnionWithLinearSizedOther() {
+        assertPerformance(.linear) { testPoint in
+            return measureMutable {
+                let benchSet = constructSet(size: testPoint)
+                let otherSet = Set.init(0..<100)
+                return time { _ = otherSet.union(benchSet) }
+            }
+        }
+    }
+
 }

--- a/Tests/PerformanceTestingTests/SetTests.swift
+++ b/Tests/PerformanceTestingTests/SetTests.swift
@@ -19,12 +19,7 @@ class SetTests: PerformanceTestCase {
         for i in 0..<n {
             set.insert(i)
         }
-        return set;
-    }
-
-    // Random number in [0, upperLimit)
-    func randomInteger(_ upperLimit: Int = 1000) -> Int {
-        return Int(arc4random_uniform(UInt32(upperLimit)))
+        return set
     }
 
     // MARK: Tests: inspecting
@@ -56,10 +51,20 @@ class SetTests: PerformanceTestCase {
     // MARK: Tests: membership
 
     // `contains` should be constant-time in the number of elements
-    func testContains() {
+    // if the element in question is in the set
+    func testContainsHit() {
         assertPerformance(.constant) { testPoint in
             let set = makeSet(size: testPoint)
-            return meanExecutionTime { _ = set.contains(randomInteger(testPoint*2)) }
+            return meanExecutionTime { _ = set.contains(testPoint.random()) }
+        }
+    }
+
+    // `contains` should be constant-time in the number of elements
+    // if the element in question is in the set
+    func testContainsMiss() {
+        assertPerformance(.constant) { testPoint in
+            let set = makeSet(size: testPoint)
+            return meanExecutionTime { _ = set.contains(testPoint+1) }
         }
     }
 
@@ -73,7 +78,7 @@ class SetTests: PerformanceTestCase {
                 return time {
                     // ensure an accurate reading, too noisy with just one iteration
                     for _ in 0..<100 {
-                        set.insert(randomInteger())
+                        set.insert((testPoint*2).random())
                     }
                 }
             }
@@ -92,12 +97,24 @@ class SetTests: PerformanceTestCase {
         }
     }
 
-    // `remove` should be constant-time in the number of elements
-    func testRemove() {
+    // `remove` should be constant-time in the number of elements,
+    // if the element to be removed is in the set
+    func testRemoveHit() {
         assertPerformance(.constant) { testPoint in
             return meanOutcome {
                 var set = makeSet(size: testPoint)
-                return time { set.remove(randomInteger(testPoint*2)) }
+                return time { set.remove(testPoint.random()) }
+            }
+        }
+    }
+
+    // `remove` should be constant-time in the number of elements,
+    // if the element to be removed is not in the set
+    func testRemoveMiss() {
+        assertPerformance(.constant) { testPoint in
+            return meanOutcome {
+                var set = makeSet(size: testPoint)
+                return time { set.remove(testPoint+1) }
             }
         }
     }

--- a/Tests/PerformanceTestingTests/SetTests.swift
+++ b/Tests/PerformanceTestingTests/SetTests.swift
@@ -13,12 +13,13 @@ class SetTests: PerformanceTestCase {
     // MARK: Helper functions.
 
     // Constructs a set of size `n` with linearly increasing elements.
-    let constructSet(size n: Int) -> [Int] {
-        var set: [Int] = []
+    func constructSet(size n: Int) -> Set<Int> {
+        var set = Set<Int>()
         set.reserveCapacity(n)
         for i in 0..<n {
             set.insert(i)
         }
+        return set;
     }
 
     // MARK: Tests: inspecting
@@ -27,7 +28,7 @@ class SetTests: PerformanceTestCase {
     func testIsEmpty() {
         assertPerformance(.constant) { testPoint in
             let set = constructSet(size: testPoint)
-            return measure { _ = array.isEmpty }
+            return measure { _ = set.isEmpty }
         }
     }
 
@@ -35,7 +36,7 @@ class SetTests: PerformanceTestCase {
     func testCount() {
         assertPerformance(.constant) { testPoint in
             let set = constructSet(size: testPoint)
-            return measure { _ = array.count }
+            return measure { _ = set.count }
         }
     }
 
@@ -43,15 +44,7 @@ class SetTests: PerformanceTestCase {
     func testFirst() {
         assertPerformance(.constant) { testPoint in
             let set = constructSet(size: testPoint)
-            return measure { _ = array.first }
-        }
-    }
-
-    // `last` should be constant-time in the number of elements
-    func testFirst() {
-        assertPerformance(.constant) { testPoint in
-            let set = constructSet(size: testPoint)
-            return measure { _ = array.last }
+            return measure { _ = set.first }
         }
     }
 

--- a/Tests/PerformanceTestingTests/SetTests.swift
+++ b/Tests/PerformanceTestingTests/SetTests.swift
@@ -33,7 +33,7 @@ class SetTests: PerformanceTestCase {
     func testIsEmpty() {
         assertPerformance(.constant) { testPoint in
             let set = makeSet(size: testPoint)
-            return measure { _ = set.isEmpty }
+            return meanExecutionTime { _ = set.isEmpty }
         }
     }
 
@@ -41,7 +41,7 @@ class SetTests: PerformanceTestCase {
     func testCount() {
         assertPerformance(.constant) { testPoint in
             let set = makeSet(size: testPoint)
-            return measure { _ = set.count }
+            return meanExecutionTime { _ = set.count }
         }
     }
 
@@ -49,7 +49,7 @@ class SetTests: PerformanceTestCase {
     func testFirst() {
         assertPerformance(.constant) { testPoint in
             let set = makeSet(size: testPoint)
-            return measure { _ = set.first }
+            return meanExecutionTime { _ = set.first }
         }
     }
 
@@ -59,7 +59,7 @@ class SetTests: PerformanceTestCase {
     func testContains() {
         assertPerformance(.constant) { testPoint in
             let set = makeSet(size: testPoint)
-            return measure { _ = set.contains(randomInteger(testPoint*2)) }
+            return meanExecutionTime { _ = set.contains(randomInteger(testPoint*2)) }
         }
     }
 
@@ -68,7 +68,7 @@ class SetTests: PerformanceTestCase {
     // `insert` should be constant-time in the number of elements
     func testInsert() {
         assertPerformance(.constant) { testPoint in
-            return measureMutable {
+            return meanOutcome {
                 var set = makeSet(size: testPoint)
                 return time {
                     // ensure an accurate reading, too noisy with just one iteration
@@ -86,7 +86,7 @@ class SetTests: PerformanceTestCase {
     func testFilter() {
         assertPerformance(.linear) { testPoint in
             let set = makeSet(size: testPoint)
-            return measure {
+            return meanExecutionTime {
                 _ = set.filter { $0 % 5 == 3 }
             }
         }
@@ -95,7 +95,7 @@ class SetTests: PerformanceTestCase {
     // `remove` should be constant-time in the number of elements
     func testRemove() {
         assertPerformance(.constant) { testPoint in
-            return measureMutable {
+            return meanOutcome {
                 var set = makeSet(size: testPoint)
                 return time { set.remove(randomInteger(testPoint*2)) }
             }
@@ -105,7 +105,7 @@ class SetTests: PerformanceTestCase {
     // `removeFirst` should be constant-time in the number of elements
     func testRemoveFirst() {
         assertPerformance(.constant) { testPoint in
-            return measureMutable {
+            return meanOutcome {
                 var set = makeSet(size: testPoint)
                 return time { set.removeFirst() }
             }
@@ -118,7 +118,7 @@ class SetTests: PerformanceTestCase {
     // Since we are inserting a constant-size set, this is constant time.
     func testUnionWithConstantSizedOther() {
         assertPerformance(.constant) { testPoint in
-            return measureMutable {
+            return meanOutcome {
                 let benchSet = makeSet(size: testPoint)
                 let otherSet = Set.init(0..<100)
                 return time { _ = benchSet.union(otherSet) }
@@ -130,7 +130,7 @@ class SetTests: PerformanceTestCase {
     // Since we are inserting a size-n set, this is linear time.
     func testUnionWithLinearSizedOther() {
         assertPerformance(.linear) { testPoint in
-            return measureMutable {
+            return meanOutcome {
                 let benchSet = makeSet(size: testPoint)
                 let otherSet = Set.init(0..<100)
                 return time { _ = otherSet.union(benchSet) }

--- a/Tests/PerformanceTestingTests/SetTests.swift
+++ b/Tests/PerformanceTestingTests/SetTests.swift
@@ -22,6 +22,11 @@ class SetTests: PerformanceTestCase {
         return set;
     }
 
+    // Random number in [0, upperLimit)
+    func randomInteger(_ upperLimit: Int = 1000) -> Int {
+        return Int(arc4random_uniform(UInt32(upperLimit)))
+    }
+
     // MARK: Tests: inspecting
 
     // `isEmpty` should be constant-time in the number of elements
@@ -50,68 +55,54 @@ class SetTests: PerformanceTestCase {
 
     // MARK: Tests: membership
 
-/*
     // `contains` should be constant-time in the number of elements
     func testContains() {
-        let data = benchmark(
-            structure: Set.init(),
-            setup: constructSizeNSet,
-            measuring: { set, n in
-                let randomNumber = Int(arc4random_uniform(UInt32(n*2)))
-                for _ in 0..<100 {
-                    _ = set.contains(randomNumber)
-                }
-            }
-        )
-        assertConstantTimePerformance(data)
+        assertPerformance(.constant) { testPoint in
+            let set = constructSet(size: testPoint)
+            return measure { _ = set.contains(randomInteger(testPoint*2)) }
+        }
     }
 
     // MARK: Tests: adding elements
 
     // `insert` should be constant-time in the number of elements
     func testInsert() {
-        let data = benchmark(
-            structure: Set.init(),
-            setup: constructSizeNSet,
-            measuring: { set, n in
-                for _ in 0..<10000 {
-                    let randomNumber = Int(arc4random_uniform(UInt32(n*2)))
-                    _ = set.insert(randomNumber)
+        assertPerformance(.constant) { testPoint in
+            return measureMutable {
+                var set = constructSet(size: testPoint)
+                return time {
+                    // ensure an accurate reading, too noisy with just one iteration
+                    for _ in 0..<100 {
+                        set.insert(randomInteger())
+                    }
                 }
             }
-        )
-        assertConstantTimePerformance(data)
+        }
     }
 
     // MARK: Tests: removing elements
 
     // `filter` should be linear in the number of elements
     func testFilter() {
-        let data = benchmark(
-            structure: Set.init(),
-            setup: constructSizeNSet,
-            measuring: { set, n in
+        assertPerformance(.linear) { testPoint in
+            let set = constructSet(size: testPoint)
+            return measure {
                 _ = set.filter { $0 % 5 == 3 }
             }
-        )
-        assertPerformanceComplexity(data, complexity: .linear)
+        }
     }
 
     // `remove` should be constant-time in the number of elements
     func testRemove() {
-        let data = benchmark(
-            structure: Set.init(),
-            setup: constructSizeNSet,
-            measuring: { set, n in
-                for _ in 0..<10000 {
-                    let randomNumber = Int(arc4random_uniform(UInt32(n*2)))
-                    _ = set.remove(randomNumber)
-                }
+        assertPerformance(.constant) { testPoint in
+            return measureMutable {
+                var set = constructSet(size: testPoint)
+                return time { set.remove(randomInteger(testPoint*2)) }
             }
-        )
-        assertConstantTimePerformance(data)
+        }
     }
 
+    /*
     // `removeFirst` should be constant-time in the number of elements
     func testRemoveFirst() {
         let data = benchmark(


### PR DESCRIPTION
in particular:
- factor Array.sum/average
- change the type of operation to (Int) -> Double
- change the type of Scale to [Int]
- add an assert to ensure constant-time performance isn't actually linear (they can look very similar w/r/t slope)
- give the API a makeover that makes it easy to write quick tests (with `assertPerformance`)
- add `measureMutable` and `time` to allow clients to write more customizable tests, benchmarking only the parts of their code they want to
- rewrite all ArrayTests with this new API

I think this is _much_ more comfortable and straightforward than the previous implementation. as always, naming could use some work