### PR TITLE
Make PerformanceTestCase instance methods free functions

### DIFF
--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -138,10 +138,14 @@ open class PerformanceTestCase: XCTestCase {
     public func meanExecutionTime(_ closure: () -> Void) -> Double {
         return meanOutcome { time(closure) }
     }
+}
 
-    public func meanOutcome(_ closure: () -> Double) -> Double {
-        return (0..<10).map { _ in closure() }.average
-    }
+/// - Returns: The mean value of ten iterations of the given `closure`.
+///
+/// - FIXME: Perhaps these values should just be mapped into a single array first?
+/// - FIXME: Maybe `10` should not be hard-coded here.
+public func meanOutcome(_ closure: () -> Double) -> Double {
+    return (0..<10).map { _ in closure() }.average
 }
 
 /// - Returns: The amount of time (in Seconds) that it takes to perform the given `closure`.

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -28,6 +28,21 @@ open class PerformanceTestCase: XCTestCase {
 
     // MARK: Instance Methods
 
+    public func assertPerformance(
+        _ complexity: Complexity,
+        testPoints: [Int],
+        of operation: (Int) -> Double
+    )
+    {
+        let data = benchmark(operation, testPoints: testPoints)
+        switch complexity {
+        case .constant:
+            assertConstantTimePerformance(data)
+        default:
+            assertPerformanceComplexity(data, complexity: complexity)
+        }
+    }
+
     /// Benchmarks the performance of a closure.
     public func benchmark(
         _ operation: (Int) -> Double,
@@ -120,20 +135,7 @@ open class PerformanceTestCase: XCTestCase {
         }
     }
 
-    public func assertPerformance(
-        _ complexity: Complexity,
-        testPoints: [Int],
-        of operation: (Int) -> Double
-    )
-    {
-        let data = benchmark(operation, testPoints: testPoints)
-        switch complexity {
-        case .constant:
-            assertConstantTimePerformance(data)
-        default:
-            assertPerformanceComplexity(data, complexity: complexity)
-        }
-    }
+
 
     public func meanExecutionTime(_ closure: () -> Void) -> Double {
         return meanOutcome { time(closure) }

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -30,21 +30,11 @@ open class PerformanceTestCase: XCTestCase {
 
     public func assertPerformance(
         _ complexity: Complexity,
-        testPoints: [Int],
+        testPoints: [Int] = Scale.medium,
         of operation: (Int) -> Double
     )
     {
         let data = benchmark(operation, testPoints: testPoints)
-        switch complexity {
-        case .constant:
-            assertConstantTimePerformance(data)
-        default:
-            assertPerformanceComplexity(data, complexity: complexity)
-        }
-    }
-
-    public func assertPerformance(_ complexity: Complexity, of operation: (Int) -> Double) {
-        let data = benchmark(operation)
         switch complexity {
         case .constant:
             assertConstantTimePerformance(data)

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -25,24 +25,22 @@ open class PerformanceTestCase: XCTestCase {
         // Controls whether any methods in this file print verbose (debugging) information
         public static var verbose: Bool = true
     }
+}
 
-    // MARK: Instance Methods
-
-    /// Assert that the given `operation` scales over the given `testPoints` (i.e., `N`) within the
-    /// given `complexity` class.
-    public func assertPerformance(
-        _ complexity: Complexity,
-        testPoints: [Int] = Scale.medium,
-        of operation: (Int) -> Double
-    )
-    {
-        let data = benchmark(operation, testPoints: testPoints)
-        switch complexity {
-        case .constant:
-            assertConstantTimePerformance(data)
-        default:
-            assertPerformanceComplexity(data, complexity: complexity)
-        }
+/// Assert that the given `operation` scales over the given `testPoints` (i.e., `N`) within the
+/// given `complexity` class.
+public func assertPerformance(
+    _ complexity: Complexity,
+    testPoints: [Int] = Scale.medium,
+    of operation: (Int) -> Double
+)
+{
+    let data = benchmark(operation, testPoints: testPoints)
+    switch complexity {
+    case .constant:
+        assertConstantTimePerformance(data)
+    default:
+        assertPerformanceComplexity(data, complexity: complexity)
     }
 }
 

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -43,6 +43,16 @@ open class PerformanceTestCase: XCTestCase {
         }
     }
 
+    public func assertPerformance(_ complexity: Complexity, of operation: (Int) -> Double) {
+        let data = benchmark(operation)
+        switch complexity {
+        case .constant:
+            assertConstantTimePerformance(data)
+        default:
+            assertPerformanceComplexity(data, complexity: complexity)
+        }
+    }
+
     /// Benchmarks the performance of a closure.
     public func benchmark(
         _ operation: (Int) -> Double,
@@ -123,16 +133,6 @@ open class PerformanceTestCase: XCTestCase {
         }
 
         XCTAssert(results.correlation >= minimumCorrelation)
-    }
-
-    public func assertPerformance(_ complexity: Complexity, of operation: (Int) -> Double) {
-        let data = benchmark(operation)
-        switch complexity {
-        case .constant:
-            assertConstantTimePerformance(data)
-        default:
-            assertPerformanceComplexity(data, complexity: complexity)
-        }
     }
 }
 

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -28,6 +28,8 @@ open class PerformanceTestCase: XCTestCase {
 
     // MARK: Instance Methods
 
+    /// Assert that the given `operation` scales over the given `testPoints` (i.e., `N`) within the
+    /// given `complexity` class.
     public func assertPerformance(
         _ complexity: Complexity,
         testPoints: [Int] = Scale.medium,

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -135,8 +135,6 @@ open class PerformanceTestCase: XCTestCase {
         }
     }
 
-
-
     public func meanExecutionTime(_ closure: () -> Void) -> Double {
         return meanOutcome { time(closure) }
     }
@@ -172,7 +170,6 @@ extension Array {
         reserveCapacity(count)
         for i in 0..<count { append(generator(i)) }
     }
-
 }
 
 extension Set {
@@ -184,7 +181,6 @@ extension Set {
         reserveCapacity(count)
         for i in 0..<count { insert(generator(i)) }
     }
-
 }
 
 extension Dictionary {
@@ -198,5 +194,4 @@ extension Dictionary {
             updateValue(element.value, forKey: element.key)
         }
     }
-
 }

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -146,10 +146,10 @@ open class PerformanceTestCase: XCTestCase {
     }
 
     public func time(_ closure: () -> Void) -> Double {
-        let startTime = CFAbsoluteTimeGetCurrent()
+        let start = CFAbsoluteTimeGetCurrent()
         closure()
-        let finishTime = CFAbsoluteTimeGetCurrent()
-        return finishTime - startTime
+        let finish = CFAbsoluteTimeGetCurrent()
+        return finish - start
     }
 }
 

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -98,34 +98,31 @@ open class PerformanceTestCase: XCTestCase {
 
         XCTAssert(results.correlation >= minimumCorrelation)
     }
+}
 
-    /// Benchmarks the performance of a closure.
-    public func benchmark(
-        _ operation: (Int) -> Double,
-        testPoints: [Int] = Scale.medium
-    ) -> Benchmark
-    {
-        let benchmarkResults = testPoints.map { testPoint -> Double in
-            var result = 3.0
-            if Configuration.verbose {
-                // So we know exactly where we're hanging. Swift seems to only
-                // flush at newlines, so manually flush here
-                print("\(#function): (\(testPoint), ", terminator:"")
-                fflush(stdout)
-            }
+/// Benchmarks the performance of a closure.
+public func benchmark(_ operation: (Int) -> Double, testPoints: [Int] = Scale.medium) -> Benchmark {
 
-            result = operation(testPoint)
-
-            if Configuration.verbose {
-                print("\(result))")
-            }
-
-            return result
+    let benchmarkResults = testPoints.map { testPoint -> Double in
+        var result = 3.0
+        if PerformanceTestCase.Configuration.verbose {
+            // So we know exactly where we're hanging. Swift seems to only
+            // flush at newlines, so manually flush here
+            print("\(#function): (\(testPoint), ", terminator:"")
+            fflush(stdout)
         }
 
-        let doubleTestPoints: [Double] = testPoints.map(Double.init)
-        return Array(zip(doubleTestPoints, benchmarkResults))
+        result = operation(testPoint)
+
+        if PerformanceTestCase.Configuration.verbose {
+            print("\(result))")
+        }
+
+        return result
     }
+
+    let doubleTestPoints: [Double] = testPoints.map(Double.init)
+    return Array(zip(doubleTestPoints, benchmarkResults))
 }
 
 /// - Returns: The mean execution of ten iterations of the given `closure`.

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -144,6 +144,7 @@ open class PerformanceTestCase: XCTestCase {
     }
 }
 
+/// - Returns: The amount of time (in Seconds) that it takes to perform the given `closure`.
 public func time(_ closure: () -> Void) -> Double {
     let start = CFAbsoluteTimeGetCurrent()
     closure()

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -134,10 +134,13 @@ open class PerformanceTestCase: XCTestCase {
             assertPerformanceComplexity(data, complexity: complexity)
         }
     }
+}
 
-    public func meanExecutionTime(_ closure: () -> Void) -> Double {
-        return meanOutcome { time(closure) }
-    }
+/// - Returns: The mean execution of ten iterations of the given `closure`.
+///
+/// - FIXME: Inject the iteraction count.
+public func meanExecutionTime(_ closure: () -> Void) -> Double {
+    return meanOutcome { time(closure) }
 }
 
 /// - Returns: The mean value of ten iterations of the given `closure`.

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -44,60 +44,60 @@ open class PerformanceTestCase: XCTestCase {
             assertPerformanceComplexity(data, complexity: complexity)
         }
     }
+}
 
-    /// Assert that the data indicates that performance is constant-time ( O(1) ).
-    public func assertConstantTimePerformance(_ benchmark: Benchmark, accuracy: Double = 0.01) {
+/// Assert that the data indicates that performance is constant-time ( O(1) ).
+public func assertConstantTimePerformance(_ benchmark: Benchmark, accuracy: Double = 0.01) {
 
-        let results = linearRegression(benchmark)
+    let results = linearRegression(benchmark)
 
-        if Configuration.verbose {
-            print("\(#function): data:")
-            for (x, y) in benchmark { print("\t(\(x), \(y))") }
+    if PerformanceTestCase.Configuration.verbose {
+        print("\(#function): data:")
+        for (x, y) in benchmark { print("\t(\(x), \(y))") }
 
-            print("\(#function): slope:       \(results.slope)")
-            print("\(#function): intercept:   \(results.intercept)")
-            print("\(#function): correlation: \(results.correlation)")
-            print("\(#function): slope acc.:  \(accuracy)")
-        }
-
-        XCTAssertEqual(results.slope, 0, accuracy: accuracy)
-        XCTAssert(results.correlation < 0.9,
-                  "Constant-time performance should not have a linearly correlated slope"
-        )
+        print("\(#function): slope:       \(results.slope)")
+        print("\(#function): intercept:   \(results.intercept)")
+        print("\(#function): correlation: \(results.correlation)")
+        print("\(#function): slope acc.:  \(accuracy)")
     }
 
-    /// Assert that the data indicates that performance fits well to the given
-    /// complexity class. Optional parameter for minimum acceptable correlation.
-    /// Use assertConstantTimePerformance for O(1) assertions
-    public func assertPerformanceComplexity(
-        _ data: Benchmark,
-        complexity: Complexity,
-        minimumCorrelation: Double = 0.9
+    XCTAssertEqual(results.slope, 0, accuracy: accuracy)
+    XCTAssert(results.correlation < 0.9,
+              "Constant-time performance should not have a linearly correlated slope"
     )
-    {
-        let mappedData = data.mappedForLinearFit(complexity: complexity)
-        let results = linearRegression(mappedData)
+}
 
-        if Configuration.verbose {
-            print("\(#function): mapped data:")
-            for (x, y) in mappedData { print("\t(\(x), \(y))") }
+/// Assert that the data indicates that performance fits well to the given
+/// complexity class. Optional parameter for minimum acceptable correlation.
+/// Use assertConstantTimePerformance for O(1) assertions
+public func assertPerformanceComplexity(
+    _ data: Benchmark,
+    complexity: Complexity,
+    minimumCorrelation: Double = 0.9
+)
+{
+    let mappedData = data.mappedForLinearFit(complexity: complexity)
+    let results = linearRegression(mappedData)
 
-            print("\(#function): slope:       \(results.slope)")
-            print("\(#function): intercept:   \(results.intercept)")
-            print("\(#function): correlation: \(results.correlation)")
-            print("\(#function): min corr.:   \(minimumCorrelation)")
-        }
+    if PerformanceTestCase.Configuration.verbose {
+        print("\(#function): mapped data:")
+        for (x, y) in mappedData { print("\t(\(x), \(y))") }
 
-        switch complexity {
-        case .constant:
-            print("\(#function): warning: constant-time complexity is not well-supported. You",
-                "probably mean assertConstantTimePerformance")
-        default:
-            break
-        }
-
-        XCTAssert(results.correlation >= minimumCorrelation)
+        print("\(#function): slope:       \(results.slope)")
+        print("\(#function): intercept:   \(results.intercept)")
+        print("\(#function): correlation: \(results.correlation)")
+        print("\(#function): min corr.:   \(minimumCorrelation)")
     }
+
+    switch complexity {
+    case .constant:
+        print("\(#function): warning: constant-time complexity is not well-supported. You",
+            "probably mean assertConstantTimePerformance")
+    default:
+        break
+    }
+
+    XCTAssert(results.correlation >= minimumCorrelation)
 }
 
 /// Benchmarks the performance of a closure.

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -142,13 +142,13 @@ open class PerformanceTestCase: XCTestCase {
     public func meanOutcome(_ closure: () -> Double) -> Double {
         return (0..<10).map { _ in closure() }.average
     }
+}
 
-    public func time(_ closure: () -> Void) -> Double {
-        let start = CFAbsoluteTimeGetCurrent()
-        closure()
-        let finish = CFAbsoluteTimeGetCurrent()
-        return finish - start
-    }
+public func time(_ closure: () -> Void) -> Double {
+    let start = CFAbsoluteTimeGetCurrent()
+    closure()
+    let finish = CFAbsoluteTimeGetCurrent()
+    return finish - start
 }
 
 extension Array where Array == Benchmark {

--- a/Sources/PerformanceTesting/PerformanceTestCase.swift
+++ b/Sources/PerformanceTesting/PerformanceTestCase.swift
@@ -53,34 +53,6 @@ open class PerformanceTestCase: XCTestCase {
         }
     }
 
-    /// Benchmarks the performance of a closure.
-    public func benchmark(
-        _ operation: (Int) -> Double,
-        testPoints: [Int] = Scale.medium
-    ) -> Benchmark
-    {
-        let benchmarkResults = testPoints.map { testPoint -> Double in
-            var result = 3.0
-            if Configuration.verbose {
-                // So we know exactly where we're hanging. Swift seems to only
-                // flush at newlines, so manually flush here
-                print("\(#function): (\(testPoint), ", terminator:"")
-                fflush(stdout)
-            }
-
-            result = operation(testPoint)
-
-            if Configuration.verbose {
-                print("\(result))")
-            }
-
-            return result
-        }
-
-        let doubleTestPoints: [Double] = testPoints.map(Double.init)
-        return Array(zip(doubleTestPoints, benchmarkResults))
-    }
-
     /// Assert that the data indicates that performance is constant-time ( O(1) ).
     public func assertConstantTimePerformance(_ benchmark: Benchmark, accuracy: Double = 0.01) {
 
@@ -98,7 +70,7 @@ open class PerformanceTestCase: XCTestCase {
 
         XCTAssertEqual(results.slope, 0, accuracy: accuracy)
         XCTAssert(results.correlation < 0.9,
-            "Constant-time performance should not have a linearly correlated slope"
+                  "Constant-time performance should not have a linearly correlated slope"
         )
     }
 
@@ -133,6 +105,34 @@ open class PerformanceTestCase: XCTestCase {
         }
 
         XCTAssert(results.correlation >= minimumCorrelation)
+    }
+
+    /// Benchmarks the performance of a closure.
+    public func benchmark(
+        _ operation: (Int) -> Double,
+        testPoints: [Int] = Scale.medium
+    ) -> Benchmark
+    {
+        let benchmarkResults = testPoints.map { testPoint -> Double in
+            var result = 3.0
+            if Configuration.verbose {
+                // So we know exactly where we're hanging. Swift seems to only
+                // flush at newlines, so manually flush here
+                print("\(#function): (\(testPoint), ", terminator:"")
+                fflush(stdout)
+            }
+
+            result = operation(testPoint)
+
+            if Configuration.verbose {
+                print("\(result))")
+            }
+
+            return result
+        }
+
+        let doubleTestPoints: [Double] = testPoints.map(Double.init)
+        return Array(zip(doubleTestPoints, benchmarkResults))
     }
 }
 

--- a/Tests/PerformanceTestingTests/ArrayTests.swift
+++ b/Tests/PerformanceTestingTests/ArrayTests.swift
@@ -102,7 +102,6 @@ class ArrayTests: PerformanceTestCase {
 
     // MARK: Tests: removing elements
 
-
     // `remove` should be constant-time in the number of elements
     func testRemove() {
         assertPerformance(.linear) { testPoint in


### PR DESCRIPTION
There were no actual dependencies on state contained by `PerformanceTestCase`, thereby requiring subclassing `XCTestCase` without any benefit.